### PR TITLE
Harden authentication defaults and admin workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+autobet.db
+.autobet.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-autobizz
+# AutoBet Backend (MVP)
+
+This repository contains a Flask-based backend prototype for the AutoBet MVP described in the product *cahier des charges*. It implements core workflows for authentication, auction lifecycle management, bidding rules, and push notification registration while staying close to the specified domain model.
+
+## Features
+
+- JWT authentication with role-based access control for admins, sellers, and buyers.
+- Administrative APIs for user provisioning and status updates.
+- Seller-facing auction CRUD with automatic 24h window enforcement and notification fan-out.
+- Buyer bidding API with validation of minimum price, highest bid requirement, and two-bid limit per auction.
+- Notification registry endpoints for Expo push tokens plus persistence of notification events.
+- `/time` endpoint exposing canonical server time for client countdown synchronization.
+- SQLAlchemy models aligned with the proposed data schema (users, auctions, bids, notifications, audit logs, devices).
+- Integration tests covering critical seller/buyer flows using pytest.
+
+## Getting started
+
+```bash
+pip install -r backend/requirements.txt
+python backend/run.py  # launches a debug server on http://127.0.0.1:5000
+```
+
+Run the automated tests:
+
+```bash
+pytest backend/tests
+```
+
+The application defaults to an in-memory SQLite database when running tests and to a local SQLite file (`autobet.db`) for development. Configure `DATABASE_URL` and `JWT_SECRET_KEY` environment variables in production deployments.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,65 @@
+"""Application factory for the AutoBet backend."""
+from datetime import timedelta
+
+from flask import Flask, jsonify
+from werkzeug.exceptions import HTTPException
+
+from . import models
+from .config import get_config
+from .extensions import db, jwt
+from .routes.admin import admin_bp
+from .routes.auth import auth_bp
+from .routes.auctions import auctions_bp
+from .routes.bids import bids_bp
+from .routes.notifications import notifications_bp
+
+
+def create_app(config_name: str | None = None) -> Flask:
+    """Create and configure the Flask application.
+
+    Parameters
+    ----------
+    config_name:
+        Optional name of the configuration to load.
+    """
+
+    app = Flask(__name__)
+    config_class = get_config(config_name)
+    app.config.from_object(config_class)
+
+    if not app.config.get("JWT_SECRET_KEY"):
+        msg = "JWT_SECRET_KEY must be configured for the application"
+        raise RuntimeError(msg)
+
+    db.init_app(app)
+    jwt.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    app.register_blueprint(auth_bp, url_prefix="/auth")
+    app.register_blueprint(admin_bp, url_prefix="/admin")
+    app.register_blueprint(auctions_bp, url_prefix="/auctions")
+    app.register_blueprint(bids_bp, url_prefix="/auctions")
+    app.register_blueprint(notifications_bp, url_prefix="/")
+
+    @app.get("/time")
+    def get_server_time() -> dict[str, str]:
+        """Return the current server time in UTC."""
+
+        return {"server_time": models.utcnow().isoformat()}
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(exc: HTTPException):
+        response = jsonify(
+            {
+                "type": exc.name,
+                "title": exc.name,
+                "detail": exc.description,
+                "status": exc.code,
+                "message": exc.description,
+            }
+        )
+        return response, exc.code
+
+    return app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,51 @@
+"""Application configuration objects."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import os
+
+
+@dataclass
+class BaseConfig:
+    """Base configuration shared across environments."""
+
+    SQLALCHEMY_DATABASE_URI: str = os.getenv(
+        "DATABASE_URL", "sqlite:///autobet.db"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
+    JWT_SECRET_KEY: str | None = os.getenv("JWT_SECRET_KEY")
+    JWT_ACCESS_TOKEN_EXPIRES: timedelta = timedelta(minutes=15)
+    JWT_REFRESH_TOKEN_EXPIRES: timedelta = timedelta(days=7)
+
+
+@dataclass
+class TestingConfig(BaseConfig):
+    """Configuration used during automated testing."""
+
+    TESTING: bool = True
+    SQLALCHEMY_DATABASE_URI: str = "sqlite:///:memory:"
+    JWT_SECRET_KEY: str = "test-secret"
+
+
+@dataclass
+class DevelopmentConfig(BaseConfig):
+    """Local development configuration."""
+
+    DEBUG: bool = True
+    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "dev-secret")
+
+
+CONFIGS: dict[str, type[BaseConfig]] = {
+    "default": BaseConfig,
+    "testing": TestingConfig,
+    "development": DevelopmentConfig,
+}
+
+
+def get_config(name: str | None) -> type[BaseConfig]:
+    """Return the configuration class matching *name*."""
+
+    if name is None:
+        return CONFIGS["default"]
+    return CONFIGS.get(name, CONFIGS["default"])

--- a/backend/app/extensions.py
+++ b/backend/app/extensions.py
@@ -1,0 +1,7 @@
+"""Shared Flask extensions."""
+from flask_jwt_extended import JWTManager
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+jwt = JWTManager()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,163 @@
+"""Database models for the AutoBet backend."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import enum
+import uuid
+
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .extensions import db
+
+
+UTC = timezone.utc
+
+
+def utcnow() -> datetime:
+    """Return the current UTC time."""
+
+    return datetime.now(UTC)
+
+
+class UserRole(enum.StrEnum):
+    ADMIN = "admin"
+    SELLER = "seller"
+    BUYER = "buyer"
+
+
+class UserStatus(enum.StrEnum):
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+
+
+class AuctionStatus(enum.StrEnum):
+    DRAFT = "draft"
+    ACTIVE = "active"
+    CLOSED = "closed"
+    CANCELLED = "cancelled"
+
+
+class NotificationType(enum.StrEnum):
+    NEW_AUCTION = "new_auction"
+    RESULT = "result"
+
+
+class BaseModel(db.Model):
+    """Mixin with UUID primary key and timestamps."""
+
+    __abstract__ = True
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        db.Uuid, primary_key=True, default=uuid.uuid4, unique=True
+    )
+    created_at: Mapped[datetime] = mapped_column(db.DateTime(timezone=True), default=utcnow)
+
+
+class User(BaseModel):
+    """Application user model."""
+
+    __tablename__ = "users"
+
+    email: Mapped[str] = mapped_column(db.String(255), unique=True, nullable=False)
+    username: Mapped[str] = mapped_column(db.String(80), unique=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    role: Mapped[UserRole] = mapped_column(db.Enum(UserRole), nullable=False)
+    status: Mapped[UserStatus] = mapped_column(
+        db.Enum(UserStatus), nullable=False, default=UserStatus.ACTIVE
+    )
+
+    auctions: Mapped[list["Auction"]] = relationship(back_populates="seller")
+    bids: Mapped[list["Bid"]] = relationship(back_populates="buyer")
+
+    def is_active(self) -> bool:
+        return self.status == UserStatus.ACTIVE
+
+
+class Auction(BaseModel):
+    """Vehicle auction model."""
+
+    __tablename__ = "auctions"
+
+    seller_id: Mapped[uuid.UUID] = mapped_column(db.Uuid, db.ForeignKey("users.id"))
+    seller: Mapped[User] = relationship(back_populates="auctions")
+
+    title: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    description: Mapped[str] = mapped_column(db.Text, nullable=False)
+    min_price: Mapped[float] = mapped_column(db.Numeric(10, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(db.String(3), default="EUR", nullable=False)
+    image_urls: Mapped[list[str]] = mapped_column(db.JSON, default=list)
+    status: Mapped[AuctionStatus] = mapped_column(
+        db.Enum(AuctionStatus), default=AuctionStatus.DRAFT, nullable=False
+    )
+    start_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+    end_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+
+    bids: Mapped[list["Bid"]] = relationship(back_populates="auction", order_by="desc(Bid.amount)")
+
+    def activate(self, *, start_time: datetime | None = None) -> None:
+        if self.status != AuctionStatus.DRAFT:
+            msg = "Only draft auctions can be activated"
+            raise ValueError(msg)
+        start = start_time or utcnow()
+        self.start_at = start
+        self.end_at = start + timedelta(hours=24)
+        self.status = AuctionStatus.ACTIVE
+
+    def close(self) -> None:
+        self.status = AuctionStatus.CLOSED
+
+    @property
+    def is_locked(self) -> bool:
+        return any(bid for bid in self.bids)
+
+
+class Bid(BaseModel):
+    """Auction bid."""
+
+    __tablename__ = "bids"
+    __table_args__ = (
+        UniqueConstraint("auction_id", "buyer_id", "idx_per_buyer"),
+    )
+
+    auction_id: Mapped[uuid.UUID] = mapped_column(db.Uuid, db.ForeignKey("auctions.id"))
+    auction: Mapped[Auction] = relationship(back_populates="bids")
+    buyer_id: Mapped[uuid.UUID] = mapped_column(db.Uuid, db.ForeignKey("users.id"))
+    buyer: Mapped[User] = relationship(back_populates="bids")
+    amount: Mapped[float] = mapped_column(db.Numeric(10, 2), nullable=False)
+    idx_per_buyer: Mapped[int] = mapped_column(db.Integer, nullable=False)
+
+
+class Notification(BaseModel):
+    """User notification record."""
+
+    __tablename__ = "notifications"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(db.Uuid, db.ForeignKey("users.id"))
+    user: Mapped[User] = relationship()
+    type: Mapped[NotificationType] = mapped_column(db.Enum(NotificationType))
+    payload: Mapped[dict] = mapped_column(db.JSON, default=dict)
+    read_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+
+
+class AuditLog(BaseModel):
+    """Administrative audit log."""
+
+    __tablename__ = "audit_logs"
+
+    actor_id: Mapped[uuid.UUID] = mapped_column(db.Uuid, db.ForeignKey("users.id"))
+    actor: Mapped[User] = relationship()
+    action: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    target_type: Mapped[str] = mapped_column(db.String(50), nullable=False)
+    target_id: Mapped[str] = mapped_column(db.String(50), nullable=False)
+    meta: Mapped[dict] = mapped_column(db.JSON, default=dict)
+
+
+class Device(BaseModel):
+    """Push notification device token registry."""
+
+    __tablename__ = "devices"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(db.Uuid, db.ForeignKey("users.id"))
+    user: Mapped[User] = relationship()
+    expo_push_token: Mapped[str] = mapped_column(db.String(255), unique=True, nullable=False)

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1,0 +1,88 @@
+"""Administrative endpoints for managing users."""
+from __future__ import annotations
+
+from http import HTTPStatus
+import uuid
+
+from flask import Blueprint, abort, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from werkzeug.security import generate_password_hash
+
+from ..extensions import db
+from ..models import AuditLog, User, UserRole, UserStatus
+from .utils import role_required
+
+
+admin_bp = Blueprint("admin", __name__)
+
+
+@admin_bp.post("/users")
+@jwt_required()
+@role_required(UserRole.ADMIN)
+def create_user():
+    data = request.get_json(force=True)
+    email = data.get("email")
+    username = data.get("username")
+    role_value = data.get("role")
+    password = data.get("password")
+
+    if not email or not username or not role_value or not password:
+        abort(HTTPStatus.BAD_REQUEST, description="Missing fields")
+
+    if role_value not in {item.value for item in UserRole}:
+        abort(HTTPStatus.BAD_REQUEST, description="Invalid role")
+
+    if len(password) < 12:
+        abort(HTTPStatus.BAD_REQUEST, description="Password must be at least 12 characters")
+
+    if User.query.filter((User.email == email) | (User.username == username)).first():
+        abort(HTTPStatus.CONFLICT, description="User already exists")
+
+    user = User(
+        email=email,
+        username=username,
+        role=UserRole(role_value),
+        password_hash=generate_password_hash(password),
+    )
+    db.session.add(user)
+
+    actor_id = uuid.UUID(str(get_jwt_identity()))
+    audit = AuditLog(
+        actor_id=actor_id,
+        action="create_user",
+        target_type="user",
+        target_id=str(user.id),
+        meta={"role": role_value},
+    )
+    db.session.add(audit)
+    db.session.commit()
+
+    return jsonify({"id": str(user.id), "role": user.role.value}), 201
+
+
+@admin_bp.patch("/users/<uuid:user_id>")
+@jwt_required()
+@role_required(UserRole.ADMIN)
+def update_user_status(user_id: uuid.UUID):
+    data = request.get_json(force=True)
+    status_value = data.get("status")
+
+    if status_value not in {item.value for item in UserStatus}:
+        abort(HTTPStatus.BAD_REQUEST, description="Invalid status")
+
+    user = User.query.filter_by(id=user_id).first()
+    if user is None:
+        abort(HTTPStatus.NOT_FOUND, description="User not found")
+
+    user.status = UserStatus(status_value)
+    actor_id = uuid.UUID(str(get_jwt_identity()))
+    audit = AuditLog(
+        actor_id=actor_id,
+        action="update_user_status",
+        target_type="user",
+        target_id=str(user.id),
+        meta={"status": status_value},
+    )
+    db.session.add(audit)
+    db.session.commit()
+    return jsonify({"id": str(user.id), "status": user.status.value})

--- a/backend/app/routes/auctions.py
+++ b/backend/app/routes/auctions.py
@@ -1,0 +1,191 @@
+"""Auction CRUD endpoints."""
+from __future__ import annotations
+
+from http import HTTPStatus
+import uuid
+
+from flask import Blueprint, abort, jsonify, request
+from flask_jwt_extended import jwt_required
+from sqlalchemy.orm import joinedload
+
+from ..extensions import db
+from ..models import (
+    Auction,
+    AuctionStatus,
+    Bid,
+    Notification,
+    NotificationType,
+    User,
+    UserRole,
+    UserStatus,
+)
+from .utils import get_current_user, role_required
+
+
+AUCTIONS_PER_PAGE = 20
+
+
+auctions_bp = Blueprint("auctions", __name__)
+
+
+@auctions_bp.get("")
+def list_auctions():
+    status_param = request.args.get("status", AuctionStatus.ACTIVE.value)
+    try:
+        status = AuctionStatus(status_param)
+    except ValueError:
+        abort(HTTPStatus.BAD_REQUEST, description="Invalid status filter")
+
+    sort = request.args.get("sort", "fresh")
+
+    query = (
+        Auction.query.options(joinedload(Auction.bids))
+        .filter_by(status=status)
+        .order_by(Auction.start_at.desc())
+    )
+    if sort != "fresh":
+        query = query.order_by(Auction.created_at.desc())
+
+    auctions = query.limit(AUCTIONS_PER_PAGE).all()
+    return jsonify([serialize_auction_preview(auction) for auction in auctions])
+
+
+@auctions_bp.post("")
+@jwt_required()
+@role_required(UserRole.SELLER)
+def create_auction():
+    user = get_current_user()
+    data = request.get_json(force=True)
+    title = data.get("title")
+    description = data.get("description")
+    min_price = data.get("min_price")
+    currency = data.get("currency", "EUR")
+    images = data.get("images", [])
+
+    if not title or not description or min_price is None:
+        abort(HTTPStatus.BAD_REQUEST, description="Missing required fields")
+
+    auction = Auction(
+        seller_id=user.id,
+        title=title,
+        description=description,
+        min_price=min_price,
+        currency=currency,
+        image_urls=images,
+        status=AuctionStatus.DRAFT,
+    )
+    auction.activate()
+    db.session.add(auction)
+    db.session.flush()
+    notify_new_auction(auction)
+    db.session.commit()
+    return jsonify(serialize_auction_detail(auction)), HTTPStatus.CREATED
+
+
+@auctions_bp.get("/<uuid:auction_id>")
+def get_auction(auction_id: uuid.UUID):
+    auction = Auction.query.options(joinedload(Auction.bids)).filter_by(id=auction_id).first()
+    if auction is None:
+        abort(HTTPStatus.NOT_FOUND, description="Auction not found")
+    return jsonify(serialize_auction_detail(auction))
+
+
+@auctions_bp.patch("/<uuid:auction_id>")
+@jwt_required()
+def update_auction(auction_id: uuid.UUID):
+    user = get_current_user()
+    auction = Auction.query.options(joinedload(Auction.bids)).filter_by(id=auction_id).first()
+    if auction is None:
+        abort(HTTPStatus.NOT_FOUND, description="Auction not found")
+
+    if auction.is_locked:
+        abort(HTTPStatus.BAD_REQUEST, description="Auction locked after first bid")
+
+    if user.role not in {UserRole.ADMIN, UserRole.SELLER}:
+        abort(HTTPStatus.FORBIDDEN, description="Insufficient permissions")
+
+    if user.role == UserRole.SELLER and auction.seller_id != user.id:
+        abort(HTTPStatus.FORBIDDEN, description="Cannot edit another seller's auction")
+
+    data = request.get_json(force=True)
+    field_map = {
+        "title": "title",
+        "description": "description",
+        "min_price": "min_price",
+        "currency": "currency",
+        "images": "image_urls",
+        "image_urls": "image_urls",
+    }
+    for json_key, model_field in field_map.items():
+        if json_key in data:
+            setattr(auction, model_field, data[json_key])
+
+    db.session.commit()
+    return jsonify(serialize_auction_detail(auction))
+
+
+@auctions_bp.delete("/<uuid:auction_id>")
+@jwt_required()
+def delete_auction(auction_id: uuid.UUID):
+    user = get_current_user()
+    auction = Auction.query.options(joinedload(Auction.bids)).filter_by(id=auction_id).first()
+    if auction is None:
+        abort(HTTPStatus.NOT_FOUND, description="Auction not found")
+
+    if auction.is_locked:
+        abort(HTTPStatus.BAD_REQUEST, description="Auction locked after first bid")
+
+    if user.role not in {UserRole.ADMIN, UserRole.SELLER}:
+        abort(HTTPStatus.FORBIDDEN, description="Insufficient permissions")
+
+    if user.role == UserRole.SELLER and auction.seller_id != user.id:
+        abort(HTTPStatus.FORBIDDEN, description="Cannot delete another seller's auction")
+
+    db.session.delete(auction)
+    db.session.commit()
+    return ("", HTTPStatus.NO_CONTENT)
+
+
+def serialize_auction_preview(auction: Auction) -> dict:
+    return {
+        "id": str(auction.id),
+        "title": auction.title,
+        "min_price": float(auction.min_price),
+        "currency": auction.currency,
+        "status": auction.status.value,
+        "start_at": auction.start_at.isoformat() if auction.start_at else None,
+        "end_at": auction.end_at.isoformat() if auction.end_at else None,
+        "best_bid": serialize_bid(auction.bids[0]) if auction.bids else None,
+    }
+
+
+def serialize_auction_detail(auction: Auction) -> dict:
+    data = serialize_auction_preview(auction)
+    data.update(
+        {
+            "description": auction.description,
+            "image_urls": auction.image_urls,
+            "seller_id": str(auction.seller_id),
+        }
+    )
+    return data
+
+
+def serialize_bid(bid: Bid) -> dict:
+    return {
+        "id": str(bid.id),
+        "amount": float(bid.amount),
+        "buyer_id": str(bid.buyer_id),
+        "created_at": bid.created_at.isoformat(),
+    }
+
+
+def notify_new_auction(auction: Auction) -> None:
+    buyers = User.query.filter_by(role=UserRole.BUYER, status=UserStatus.ACTIVE).all()
+    for buyer in buyers:
+        notification = Notification(
+            user_id=buyer.id,
+            type=NotificationType.NEW_AUCTION,
+            payload={"auction_id": str(auction.id)},
+        )
+        db.session.add(notification)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,139 @@
+"""Authentication and authorization endpoints."""
+from __future__ import annotations
+
+from http import HTTPStatus
+import uuid
+
+from flask import Blueprint, abort, jsonify, request
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+    get_jwt,
+    get_jwt_identity,
+    jwt_required,
+)
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from ..extensions import db
+from ..models import AuditLog, User, UserRole, UserStatus
+from .utils import role_required
+
+
+auth_bp = Blueprint("auth", __name__)
+
+
+@auth_bp.post("/register")
+def register_user():
+    data = request.get_json(force=True)
+    username = data.get("username")
+    email = data.get("email")
+    password = data.get("password")
+    requested_role = data.get("role")
+
+    if not username or not password or not email:
+        abort(HTTPStatus.BAD_REQUEST, description="Missing required fields")
+
+    if requested_role and requested_role != UserRole.BUYER.value:
+        abort(HTTPStatus.FORBIDDEN, description="Role selection is restricted")
+
+    if User.query.filter((User.email == email) | (User.username == username)).first():
+        abort(HTTPStatus.CONFLICT, description="User already exists")
+
+    user = User(
+        username=username,
+        email=email,
+        password_hash=generate_password_hash(password),
+        role=UserRole.BUYER,
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    return jsonify({"id": str(user.id), "username": user.username, "role": user.role.value}), 201
+
+
+@auth_bp.post("/login")
+def login():
+    data = request.get_json(force=True)
+    identifier = data.get("usernameOrEmail")
+    password = data.get("password")
+    if not identifier or not password:
+        abort(HTTPStatus.BAD_REQUEST, description="Missing credentials")
+
+    user = User.query.filter(
+        (User.username == identifier) | (User.email == identifier)
+    ).first()
+    if user is None or not check_password_hash(user.password_hash, password):
+        abort(HTTPStatus.UNAUTHORIZED, description="Invalid credentials")
+
+    if not user.is_active():
+        abort(HTTPStatus.FORBIDDEN, description="User suspended")
+
+    additional_claims = {"role": user.role.value, "status": user.status.value}
+    return jsonify(
+        {
+            "access": create_access_token(identity=str(user.id), additional_claims=additional_claims),
+            "refresh": create_refresh_token(identity=str(user.id), additional_claims=additional_claims),
+        }
+    )
+
+
+@auth_bp.post("/refresh")
+@jwt_required(refresh=True)
+def refresh_token():
+    identity = get_jwt_identity()
+    claims = get_jwt()
+    role = claims.get("role", UserRole.BUYER.value)
+    status = claims.get("status", UserStatus.ACTIVE.value)
+    return jsonify(
+        {
+            "access": create_access_token(
+                identity=identity, additional_claims={"role": role, "status": status}
+            )
+        }
+    )
+
+
+@auth_bp.post("/invite")
+@jwt_required()
+@role_required(UserRole.ADMIN)
+def invite_user():
+    data = request.get_json(force=True)
+    email = data.get("email")
+    role_value = data.get("role", UserRole.BUYER.value)
+
+    if role_value not in {item.value for item in UserRole}:
+        abort(HTTPStatus.BAD_REQUEST, description="Invalid role")
+
+    actor_id = uuid.UUID(str(get_jwt_identity()))
+    audit = AuditLog(
+        actor_id=actor_id,
+        action="invite_user",
+        target_type="user",
+        target_id=email or "unknown",
+        meta={"role": role_value},
+    )
+    db.session.add(audit)
+    db.session.commit()
+    return jsonify({"message": "Invitation recorded"}), 201
+
+
+@auth_bp.post("/reset")
+@jwt_required()
+@role_required(UserRole.ADMIN)
+def reset_password():
+    data = request.get_json(force=True)
+    user_id = data.get("user_id")
+    user = User.query.filter_by(id=user_id).first()
+    if user is None:
+        abort(HTTPStatus.NOT_FOUND, description="User not found")
+
+    actor_id = uuid.UUID(str(get_jwt_identity()))
+    audit = AuditLog(
+        actor_id=actor_id,
+        action="reset_password",
+        target_type="user",
+        target_id=str(user.id),
+    )
+    db.session.add(audit)
+    db.session.commit()
+    return jsonify({"message": "Password reset dispatched"})

--- a/backend/app/routes/bids.py
+++ b/backend/app/routes/bids.py
@@ -1,0 +1,97 @@
+"""Bid placement endpoints."""
+from __future__ import annotations
+
+from decimal import Decimal
+from http import HTTPStatus
+import uuid
+
+from flask import Blueprint, abort, jsonify, request
+from flask_jwt_extended import jwt_required
+from ..extensions import db
+from ..models import (
+    Auction,
+    AuctionStatus,
+    Bid,
+    Notification,
+    NotificationType,
+    UserRole,
+    UTC,
+    utcnow,
+)
+from .utils import get_current_user, role_required
+
+
+bids_bp = Blueprint("bids", __name__)
+
+
+@bids_bp.post("/<uuid:auction_id>/bids")
+@jwt_required()
+@role_required(UserRole.BUYER)
+def place_bid(auction_id: uuid.UUID):
+    user = get_current_user()
+    data = request.get_json(force=True)
+    amount = data.get("amount")
+
+    if amount is None:
+        abort(HTTPStatus.BAD_REQUEST, description="Missing bid amount")
+
+    auction = Auction.query.filter_by(id=auction_id).first()
+    if auction is None:
+        abort(HTTPStatus.NOT_FOUND, description="Auction not found")
+
+    if auction.status != AuctionStatus.ACTIVE:
+        abort(HTTPStatus.BAD_REQUEST, description="Auction not active")
+
+    end_at = auction.end_at
+    if end_at is not None and end_at.tzinfo is None:
+        end_at = end_at.replace(tzinfo=UTC)
+    if end_at and end_at <= utcnow():
+        abort(HTTPStatus.BAD_REQUEST, description="Auction already closed")
+
+    existing_count = Bid.query.filter_by(auction_id=auction_id, buyer_id=user.id).count()
+    if existing_count >= 2:
+        abort(HTTPStatus.BAD_REQUEST, description="Bid limit reached for this auction")
+
+    amount_decimal = Decimal(str(amount))
+    min_price = Decimal(str(auction.min_price))
+    if amount_decimal < min_price:
+        abort(HTTPStatus.BAD_REQUEST, description="Bid below minimum price")
+
+    top_bid = Bid.query.filter_by(auction_id=auction_id).order_by(Bid.amount.desc()).first()
+    if top_bid and amount_decimal <= Decimal(str(top_bid.amount)):
+        abort(HTTPStatus.BAD_REQUEST, description="Bid must be higher than current best")
+
+    bid = Bid(
+        auction_id=auction_id,
+        buyer_id=user.id,
+        amount=amount_decimal,
+        idx_per_buyer=existing_count + 1,
+    )
+    db.session.add(bid)
+    db.session.flush()
+
+    notify_bid_outcome(auction, bid)
+
+    db.session.commit()
+    return jsonify({"bid": serialize_bid(bid)}), HTTPStatus.CREATED
+
+
+def serialize_bid(bid: Bid) -> dict:
+    return {
+        "id": str(bid.id),
+        "amount": float(bid.amount),
+        "buyer_id": str(bid.buyer_id),
+        "created_at": bid.created_at.isoformat(),
+    }
+
+
+def notify_bid_outcome(auction: Auction, bid: Bid) -> None:
+    notification = Notification(
+        user_id=auction.seller_id,
+        type=NotificationType.RESULT,
+        payload={
+            "auction_id": str(auction.id),
+            "latest_bid": serialize_bid(bid),
+        },
+    )
+    db.session.add(notification)

--- a/backend/app/routes/notifications.py
+++ b/backend/app/routes/notifications.py
@@ -1,0 +1,35 @@
+"""Notification endpoints."""
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Blueprint, abort, jsonify, request
+from flask_jwt_extended import jwt_required
+
+from ..extensions import db
+from ..models import Device
+from .utils import get_current_user
+
+
+notifications_bp = Blueprint("notifications", __name__)
+
+
+@notifications_bp.post("/devices")
+@jwt_required()
+def register_device():
+    user = get_current_user()
+    data = request.get_json(force=True)
+    token = data.get("expo_push_token")
+
+    if not token:
+        abort(HTTPStatus.BAD_REQUEST, description="Missing expo_push_token")
+
+    device = Device.query.filter_by(expo_push_token=token).first()
+    if device is None:
+        device = Device(user_id=user.id, expo_push_token=token)
+        db.session.add(device)
+    else:
+        device.user_id = user.id
+
+    db.session.commit()
+    return jsonify({"device_id": str(device.id)}), HTTPStatus.CREATED

--- a/backend/app/routes/utils.py
+++ b/backend/app/routes/utils.py
@@ -1,0 +1,44 @@
+"""Utility helpers for route modules."""
+from __future__ import annotations
+
+from functools import wraps
+import uuid
+from typing import Callable, TypeVar
+
+from flask import abort
+from flask_jwt_extended import get_jwt, get_jwt_identity
+
+from ..models import User
+
+from ..models import UserRole
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def role_required(*allowed_roles: UserRole) -> Callable[[F], F]:
+    """Ensure the current JWT contains one of the *allowed_roles*."""
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            claims = get_jwt()
+            role = claims.get("role")
+            if role not in {value.value for value in allowed_roles}:
+                abort(403, description="Insufficient permissions")
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def get_current_user() -> User:
+    """Return the authenticated user from the JWT identity."""
+
+    identity = get_jwt_identity()
+    user = User.query.filter_by(id=uuid.UUID(str(identity))).first()
+    if user is None:
+        abort(401, description="Unknown user")
+    if not user.is_active():
+        abort(403, description="User account is suspended")
+    return user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+flask==3.0.2
+flask-sqlalchemy==3.1.1
+flask-jwt-extended==4.6.0
+pytest==8.1.1
+itsdangerous==2.1.2
+werkzeug==3.0.1

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,11 @@
+"""Entry-point for running the AutoBet backend locally."""
+from __future__ import annotations
+
+from app import create_app
+
+
+app = create_app("development")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared pytest fixtures."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+from app import create_app
+from app.extensions import db
+
+
+@pytest.fixture()
+def app():
+    app = create_app("testing")
+    ctx = app.app_context()
+    ctx.push()
+
+    yield app
+
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/backend/tests/test_auction_flow.py
+++ b/backend/tests/test_auction_flow.py
@@ -1,0 +1,148 @@
+"""Integration tests covering core auction workflows."""
+from __future__ import annotations
+
+from werkzeug.security import generate_password_hash
+
+from app.extensions import db
+from app.models import Notification, NotificationType, User, UserRole
+
+
+ADMIN_PASSWORD = "AdminPassw0rd!"
+SELLER_PASSWORD = "SellerPassw0rd!"
+BUYER_PASSWORD = "BuyerPassw0rd!"
+
+
+def ensure_admin_user(client) -> None:
+    app = client.application
+    with app.app_context():
+        if User.query.filter_by(username="admin").first() is None:
+            admin = User(
+                username="admin",
+                email="admin@example.com",
+                role=UserRole.ADMIN,
+                password_hash=generate_password_hash(ADMIN_PASSWORD),
+            )
+            db.session.add(admin)
+            db.session.commit()
+
+
+def register_buyer(client, username: str, email: str, password: str):
+    response = client.post(
+        "/auth/register",
+        json={"username": username, "email": email, "password": password},
+    )
+    assert response.status_code == 201
+    return response.get_json()
+
+
+def login_user(client, identifier: str, password: str) -> str:
+    response = client.post(
+        "/auth/login",
+        json={"usernameOrEmail": identifier, "password": password},
+    )
+    assert response.status_code == 200
+    return response.get_json()["access"]
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_seller_can_create_and_buyer_can_bid(client):
+    ensure_admin_user(client)
+    admin_token = login_user(client, "admin", ADMIN_PASSWORD)
+
+    register_buyer(client, "buyer1", "buyer1@example.com", BUYER_PASSWORD)
+    create_seller_response = client.post(
+        "/admin/users",
+        headers=auth_headers(admin_token),
+        json={
+            "email": "seller1@example.com",
+            "username": "seller1",
+            "role": UserRole.SELLER.value,
+            "password": SELLER_PASSWORD,
+        },
+    )
+    assert create_seller_response.status_code == 201
+
+    seller_token = login_user(client, "seller1", SELLER_PASSWORD)
+
+    create_response = client.post(
+        "/auctions",
+        headers=auth_headers(seller_token),
+        json={
+            "title": "Tesla Model S",
+            "description": "Performance trim",
+            "min_price": 50000,
+            "currency": "EUR",
+            "images": ["https://example.com/car.jpg"],
+        },
+    )
+    assert create_response.status_code == 201
+    auction_data = create_response.get_json()
+    auction_id = auction_data["id"]
+
+    buyer_token = login_user(client, "buyer1", BUYER_PASSWORD)
+
+    bid_response = client.post(
+        f"/auctions/{auction_id}/bids",
+        headers=auth_headers(buyer_token),
+        json={"amount": 51000},
+    )
+    assert bid_response.status_code == 201
+    bid_data = bid_response.get_json()["bid"]
+    assert bid_data["amount"] == 51000.0
+
+    list_response = client.get("/auctions")
+    assert list_response.status_code == 200
+    listings = list_response.get_json()
+    assert listings[0]["best_bid"]["amount"] == 51000.0
+
+    notifications = Notification.query.all()
+    assert any(n.type == NotificationType.NEW_AUCTION for n in notifications)
+    assert any(n.type == NotificationType.RESULT for n in notifications)
+
+
+def test_buyer_cannot_exceed_bid_limit(client):
+    ensure_admin_user(client)
+    admin_token = login_user(client, "admin", ADMIN_PASSWORD)
+
+    create_seller_response = client.post(
+        "/admin/users",
+        headers=auth_headers(admin_token),
+        json={
+            "email": "seller2@example.com",
+            "username": "seller2",
+            "role": UserRole.SELLER.value,
+            "password": SELLER_PASSWORD,
+        },
+    )
+    assert create_seller_response.status_code == 201
+
+    seller_token = login_user(client, "seller2", SELLER_PASSWORD)
+
+    auction_resp = client.post(
+        "/auctions",
+        headers=auth_headers(seller_token),
+        json={"title": "Renault 5", "description": "Classic", "min_price": 1000},
+    )
+    auction_id = auction_resp.get_json()["id"]
+
+    register_buyer(client, "buyer2", "buyer2@example.com", BUYER_PASSWORD)
+    buyer_token = login_user(client, "buyer2", BUYER_PASSWORD)
+
+    for amount in (1200, 1500):
+        response = client.post(
+            f"/auctions/{auction_id}/bids",
+            headers=auth_headers(buyer_token),
+            json={"amount": amount},
+        )
+        assert response.status_code == 201
+
+    third_bid = client.post(
+        f"/auctions/{auction_id}/bids",
+        headers=auth_headers(buyer_token),
+        json={"amount": 2000},
+    )
+    assert third_bid.status_code == 400
+    assert "limit" in third_bid.get_json()["message"].lower()

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,1 @@
+-r backend/requirements.txt


### PR DESCRIPTION
## Summary
- enforce explicit JWT secret configuration and fail application start without it
- restrict self-registration to the buyer role, ensure suspended users cannot act, and require strong passwords for admin-created accounts
- update integration tests to cover the admin-driven seller creation flow aligned with the tighter security defaults

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68deb3c4541483308f1eb00ed6113199