### PR TITLE
Fix login and registration flows in Expo client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 .env
 autobet.db
 .autobet.db
+node_modules/
+frontend/node_modules/

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -14,7 +14,7 @@ function RootNavigator() {
   const { isAuthenticated } = useAuth();
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator key={isAuthenticated ? 'app' : 'auth'}>
       {isAuthenticated ? (
         <>
           <Stack.Screen name="Auctions" component={AuctionListScreen} options={{ headerShown: false }} />

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,6 +24,7 @@ This directory contains a lightweight Expo/React Native client for interacting w
    ```bash
    cd frontend
    npm install
+   npx expo install react-native-web react-dom @expo/metro-runtime
    ```
 
 2. Optionally configure the backend URL exposed to the Expo client by creating an `.env` file in this folder:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,11 @@
     "expo": "~50.0.7",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-native": "0.73.6",
+    "react-native-web": "~0.19.10",
     "react-native-safe-area-context": "^4.8.2",
-    "react-native-screens": "~3.29.0"
+    "react-native-screens": "~3.29.0",
+    "@expo/metro-runtime": "~2.0.5"
   }
 }

--- a/frontend/src/screens/LoginScreen.js
+++ b/frontend/src/screens/LoginScreen.js
@@ -25,7 +25,6 @@ export default function LoginScreen({ navigation }) {
       const tokens = await loginRequest({ usernameOrEmail, password });
       const claims = parseJwt(tokens.access);
       login(tokens, { role: claims?.role ?? null });
-      navigation.replace('Auctions');
     } catch (error) {
       Alert.alert('Login failed', error.message);
     } finally {

--- a/frontend/src/screens/RegisterScreen.js
+++ b/frontend/src/screens/RegisterScreen.js
@@ -21,8 +21,16 @@ export default function RegisterScreen({ navigation }) {
     setLoading(true);
     try {
       await registerRequest({ username, email, password });
-      Alert.alert('Success', 'Account created. You can now log in.');
-      navigation.goBack();
+      Alert.alert('Success', 'Account created. You can now log in.', [
+        {
+          text: 'Go to login',
+          onPress: () =>
+            navigation.reset({
+              index: 0,
+              routes: [{ name: 'Login' }],
+            }),
+        },
+      ]);
     } catch (error) {
       Alert.alert('Registration failed', error.message);
     } finally {


### PR DESCRIPTION
## Summary
- reset the navigation stack when authentication state changes so login transitions to the auction screens
- improve register/login flows by removing the invalid replace call and resetting to the login screen after creating an account
- add the Expo web dependencies and documentation for installing them, and ignore node_modules in git

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f4de3003fc83308fe1d51eba53e992