### PR TITLE
Allow Expo web client to access API via CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 .env
 autobet.db
 .autobet.db
+node_modules/
+frontend/node_modules/

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,7 +1,7 @@
 """Application factory for the AutoBet backend."""
-from datetime import timedelta
 
 from flask import Flask, jsonify
+from flask_cors import CORS
 from werkzeug.exceptions import HTTPException
 
 from . import models
@@ -26,6 +26,7 @@ def create_app(config_name: str | None = None) -> Flask:
     app = Flask(__name__)
     config_class = get_config(config_name)
     app.config.from_object(config_class)
+    CORS(app, resources={r"/*": {"origins": app.config.get("CORS_ORIGINS", "*")}})
 
     if not app.config.get("JWT_SECRET_KEY"):
         msg = "JWT_SECRET_KEY must be configured for the application"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,7 @@ class BaseConfig:
     JWT_SECRET_KEY: str | None = os.getenv("JWT_SECRET_KEY")
     JWT_ACCESS_TOKEN_EXPIRES: timedelta = timedelta(minutes=15)
     JWT_REFRESH_TOKEN_EXPIRES: timedelta = timedelta(days=7)
+    CORS_ORIGINS: str = os.getenv("CORS_ORIGINS", "*")
 
 
 @dataclass

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 flask==3.0.2
+flask-cors==4.0.0
 flask-sqlalchemy==3.1.1
 flask-jwt-extended==4.6.0
 pytest==8.1.1

--- a/backend/tests/test_auction_flow.py
+++ b/backend/tests/test_auction_flow.py
@@ -146,3 +146,16 @@ def test_buyer_cannot_exceed_bid_limit(client):
     )
     assert third_bid.status_code == 400
     assert "limit" in third_bid.get_json()["message"].lower()
+
+
+def test_cors_headers_allow_frontend_origin(client):
+    origin = "http://localhost:19006"
+    response = client.options(
+        "/auth/login",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("Access-Control-Allow-Origin") in {"*", origin}

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -14,7 +14,7 @@ function RootNavigator() {
   const { isAuthenticated } = useAuth();
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator key={isAuthenticated ? 'app' : 'auth'}>
       {isAuthenticated ? (
         <>
           <Stack.Screen name="Auctions" component={AuctionListScreen} options={{ headerShown: false }} />

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,6 +24,7 @@ This directory contains a lightweight Expo/React Native client for interacting w
    ```bash
    cd frontend
    npm install
+   npx expo install react-native-web react-dom @expo/metro-runtime
    ```
 
 2. Optionally configure the backend URL exposed to the Expo client by creating an `.env` file in this folder:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,11 @@
     "expo": "~50.0.7",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-native": "0.73.6",
+    "react-native-web": "~0.19.10",
     "react-native-safe-area-context": "^4.8.2",
-    "react-native-screens": "~3.29.0"
+    "react-native-screens": "~3.29.0",
+    "@expo/metro-runtime": "~2.0.5"
   }
 }

--- a/frontend/src/screens/LoginScreen.js
+++ b/frontend/src/screens/LoginScreen.js
@@ -25,7 +25,6 @@ export default function LoginScreen({ navigation }) {
       const tokens = await loginRequest({ usernameOrEmail, password });
       const claims = parseJwt(tokens.access);
       login(tokens, { role: claims?.role ?? null });
-      navigation.replace('Auctions');
     } catch (error) {
       Alert.alert('Login failed', error.message);
     } finally {

--- a/frontend/src/screens/RegisterScreen.js
+++ b/frontend/src/screens/RegisterScreen.js
@@ -21,8 +21,16 @@ export default function RegisterScreen({ navigation }) {
     setLoading(true);
     try {
       await registerRequest({ username, email, password });
-      Alert.alert('Success', 'Account created. You can now log in.');
-      navigation.goBack();
+      Alert.alert('Success', 'Account created. You can now log in.', [
+        {
+          text: 'Go to login',
+          onPress: () =>
+            navigation.reset({
+              index: 0,
+              routes: [{ name: 'Login' }],
+            }),
+        },
+      ]);
     } catch (error) {
       Alert.alert('Registration failed', error.message);
     } finally {


### PR DESCRIPTION
## Summary
- allow configuring CORS origins and enable CORS for every backend route so browser clients can reach the API
- add flask-cors dependency and test coverage for the preflight on the login endpoint

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f4de3003fc83308fe1d51eba53e992