### PR TITLE
Add admin auction management view with creation form

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -6,24 +6,36 @@ import AuctionDetailScreen from './src/screens/AuctionDetailScreen';
 import AuctionListScreen from './src/screens/AuctionListScreen';
 import LoginScreen from './src/screens/LoginScreen';
 import RegisterScreen from './src/screens/RegisterScreen';
+import AdminHomeScreen from './src/screens/AdminHomeScreen';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
 
 const Stack = createNativeStackNavigator();
 
 function RootNavigator() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, role } = useAuth();
 
   return (
     <Stack.Navigator key={isAuthenticated ? 'app' : 'auth'}>
       {isAuthenticated ? (
-        <>
-          <Stack.Screen name="Auctions" component={AuctionListScreen} options={{ headerShown: false }} />
-          <Stack.Screen
-            name="AuctionDetail"
-            component={AuctionDetailScreen}
-            options={{ title: 'Auction detail' }}
-          />
-        </>
+        role === 'admin' ? (
+          <>
+            <Stack.Screen name="Admin" component={AdminHomeScreen} options={{ headerShown: false }} />
+            <Stack.Screen
+              name="AuctionDetail"
+              component={AuctionDetailScreen}
+              options={{ title: 'Auction detail' }}
+            />
+          </>
+        ) : (
+          <>
+            <Stack.Screen name="Auctions" component={AuctionListScreen} options={{ headerShown: false }} />
+            <Stack.Screen
+              name="AuctionDetail"
+              component={AuctionDetailScreen}
+              options={{ title: 'Auction detail' }}
+            />
+          </>
+        )
       ) : (
         <>
           <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
+    "expo-image-picker": "~14.7.1",
     "base-64": "^1.0.0",
     "expo": "~50.0.7",
     "expo-status-bar": "~1.11.1",

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -64,10 +64,19 @@ export async function placeBid(auctionId, amount, token) {
   });
 }
 
+export async function createAuction(data, token) {
+  return request('/auctions', {
+    method: 'POST',
+    token,
+    body: data,
+  });
+}
+
 export default {
   register,
   login,
   listAuctions,
   fetchAuction,
   placeBid,
+  createAuction,
 };

--- a/frontend/src/components/AdminNewAuctionForm.js
+++ b/frontend/src/components/AdminNewAuctionForm.js
@@ -1,0 +1,243 @@
+import React, { useState } from 'react';
+import {
+  Alert,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { createAuction } from '../api/client';
+import { useAuth } from '../context/AuthContext';
+
+export default function AdminNewAuctionForm({ onCreated }) {
+  const { accessToken } = useAuth();
+  const [title, setTitle] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const pickImage = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission required', 'Allow access to your photos to upload a vehicle picture.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+      base64: true,
+    });
+
+    if (result.canceled) {
+      return;
+    }
+
+    const asset = result.assets?.[0];
+    if (!asset) {
+      return;
+    }
+
+    const mimeType = asset.mimeType || 'image/jpeg';
+    const dataUrl = asset.base64 ? `data:${mimeType};base64,${asset.base64}` : asset.uri;
+    setSelectedImage({
+      uri: asset.uri,
+      dataUrl,
+    });
+  };
+
+  const handleCreateAuction = async () => {
+    if (!title.trim()) {
+      Alert.alert('Missing title', 'Please provide a descriptive auction name.');
+      return;
+    }
+
+    const numericMinPrice = Number(minPrice);
+    if (!minPrice || Number.isNaN(numericMinPrice) || numericMinPrice <= 0) {
+      Alert.alert('Invalid price', 'Enter a valid minimum price greater than 0.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await createAuction(
+        {
+          title: title.trim(),
+          min_price: numericMinPrice,
+          description: title.trim(),
+          currency: 'EUR',
+          images: selectedImage ? [selectedImage.dataUrl] : [],
+        },
+        accessToken,
+      );
+      setTitle('');
+      setMinPrice('');
+      setSelectedImage(null);
+      Alert.alert('Auction created', 'The auction has been published successfully.');
+      if (onCreated) {
+        onCreated();
+      }
+    } catch (error) {
+      Alert.alert('Creation failed', error.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+    >
+      <ScrollView contentContainerStyle={styles.form}>
+        <Text style={styles.formTitle}>Register a new auction</Text>
+        <Text style={styles.helper}>Fill in the auction details below to publish it immediately.</Text>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Auction name</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g. 2019 Tesla Model 3"
+            value={title}
+            onChangeText={setTitle}
+            autoCapitalize="words"
+            returnKeyType="next"
+          />
+        </View>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Minimum price (EUR)</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g. 25000"
+            keyboardType="decimal-pad"
+            value={minPrice}
+            onChangeText={setMinPrice}
+          />
+        </View>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Vehicle photo</Text>
+          {selectedImage ? (
+            <View style={styles.previewContainer}>
+              <Image source={{ uri: selectedImage.uri }} style={styles.preview} resizeMode="cover" />
+              <Pressable onPress={() => setSelectedImage(null)} style={styles.clearButton}>
+                <Text style={styles.clearLabel}>Remove photo</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <Pressable style={styles.uploadButton} onPress={pickImage}>
+              <Text style={styles.uploadLabel}>Upload a photo</Text>
+            </Pressable>
+          )}
+          {selectedImage ? null : (
+            <Text style={styles.helperSmall}>Supported formats: jpg, png. The selected image is attached to the listing.</Text>
+          )}
+        </View>
+
+        <Pressable
+          onPress={handleCreateAuction}
+          style={({ pressed }) => [styles.submitButton, pressed && styles.submitPressed]}
+          disabled={isSubmitting}
+        >
+          <Text style={styles.submitLabel}>{isSubmitting ? 'Creating…' : 'Create auction'}</Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  form: {
+    paddingHorizontal: 20,
+    paddingBottom: 32,
+  },
+  formTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginTop: 24,
+    marginBottom: 8,
+  },
+  helper: {
+    color: '#4a4a4a',
+    marginBottom: 16,
+  },
+  helperSmall: {
+    color: '#6f6f6f',
+    marginTop: 6,
+    fontSize: 12,
+  },
+  fieldGroup: {
+    marginBottom: 20,
+  },
+  label: {
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: '#d0d5dd',
+    fontSize: 16,
+  },
+  uploadButton: {
+    borderWidth: 1,
+    borderColor: '#0f62fe',
+    borderStyle: 'dashed',
+    borderRadius: 12,
+    paddingVertical: 24,
+    alignItems: 'center',
+    backgroundColor: '#eef3ff',
+  },
+  uploadLabel: {
+    color: '#0f62fe',
+    fontWeight: '600',
+  },
+  previewContainer: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  preview: {
+    width: '100%',
+    height: 200,
+  },
+  clearButton: {
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#d0d5dd',
+  },
+  clearLabel: {
+    color: '#d92d20',
+    fontWeight: '600',
+  },
+  submitButton: {
+    backgroundColor: '#0f62fe',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  submitPressed: {
+    opacity: 0.8,
+  },
+  submitLabel: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+});

--- a/frontend/src/screens/AdminHomeScreen.js
+++ b/frontend/src/screens/AdminHomeScreen.js
@@ -1,0 +1,132 @@
+import React, { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { useAuth } from '../context/AuthContext';
+import AdminNewAuctionForm from '../components/AdminNewAuctionForm';
+import AuctionListScreen from './AuctionListScreen';
+
+export default function AdminHomeScreen({ navigation }) {
+  const { logout } = useAuth();
+  const [activeTab, setActiveTab] = useState('admin');
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const goToAdmin = useCallback(() => setActiveTab('admin'), []);
+  const goToAuctions = useCallback(() => setActiveTab('auctions'), []);
+
+  useFocusEffect(
+    useCallback(() => {
+      setActiveTab('admin');
+    }, []),
+  );
+
+  const handleCreated = () => {
+    setRefreshKey((current) => current + 1);
+    setActiveTab('auctions');
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <View style={styles.headerText}>
+          <Text style={styles.title}>Admin workspace</Text>
+          <Text style={styles.subtitle}>Register new auctions or browse live listings</Text>
+        </View>
+        <Pressable onPress={logout} style={styles.logoutButton}>
+          <Text style={styles.logout}>Log out</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.tabBar}>
+        <Pressable
+          onPress={goToAdmin}
+          style={[styles.tabButton, activeTab === 'admin' && styles.tabButtonActive]}
+        >
+          <Text style={[styles.tabLabel, activeTab === 'admin' && styles.tabLabelActive]}>Admin view</Text>
+        </Pressable>
+        <Pressable
+          onPress={goToAuctions}
+          style={[styles.tabButton, activeTab === 'auctions' && styles.tabButtonActive]}
+        >
+          <Text style={[styles.tabLabel, activeTab === 'auctions' && styles.tabLabelActive]}>Auction view</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.content}>
+        {activeTab === 'admin' ? (
+          <AdminNewAuctionForm onCreated={handleCreated} />
+        ) : (
+          <AuctionListScreen key={`admin-auctions-${refreshKey}`} navigation={navigation} />
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f2f4f8',
+  },
+  header: {
+    paddingTop: 48,
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  headerText: {
+    flex: 1,
+    marginRight: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+  },
+  subtitle: {
+    marginTop: 4,
+    color: '#4a4a4a',
+  },
+  logoutButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#ffe5e5',
+  },
+  logout: {
+    color: '#d92d20',
+    fontWeight: '600',
+  },
+  tabBar: {
+    flexDirection: 'row',
+    backgroundColor: '#e0e5f2',
+    marginHorizontal: 20,
+    borderRadius: 12,
+    padding: 4,
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  tabButtonActive: {
+    backgroundColor: '#fff',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  tabLabel: {
+    fontWeight: '500',
+    color: '#3d3d3d',
+  },
+  tabLabelActive: {
+    color: '#0f62fe',
+    fontWeight: '600',
+  },
+  content: {
+    flex: 1,
+    marginTop: 16,
+  },
+});

--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   Alert,
+  Image,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -89,6 +90,9 @@ export default function AuctionDetailScreen({ route }) {
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <Text style={styles.title}>{auction.title}</Text>
       <Text style={styles.subtitle}>{auction.description}</Text>
+      {auction.image_urls && auction.image_urls[0] ? (
+        <Image source={{ uri: auction.image_urls[0] }} style={styles.heroImage} resizeMode="cover" />
+      ) : null}
       <Text style={styles.meta}>Minimum price: {auction.min_price} {auction.currency}</Text>
       <Text style={styles.meta}>Status: {auction.status}</Text>
       {auction.end_at ? (
@@ -146,6 +150,13 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#4a4a4a',
     marginBottom: 16,
+  },
+  heroImage: {
+    width: '100%',
+    height: 220,
+    borderRadius: 16,
+    marginBottom: 16,
+    backgroundColor: '#e5e5e5',
   },
   meta: {
     fontSize: 14,

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   FlatList,
+  Image,
   Pressable,
   RefreshControl,
   StyleSheet,
@@ -14,8 +15,12 @@ import { useAuth } from '../context/AuthContext';
 
 function AuctionCard({ auction, onPress }) {
   const bestBid = auction.best_bid;
+  const previewImage = auction.image_urls && auction.image_urls[0];
   return (
     <Pressable style={styles.card} onPress={onPress}>
+      {previewImage ? (
+        <Image source={{ uri: previewImage }} style={styles.cardImage} resizeMode="cover" />
+      ) : null}
       <Text style={styles.cardTitle}>{auction.title}</Text>
       <View style={styles.cardRow}>
         <Text style={styles.cardLabel}>Minimum:</Text>
@@ -135,6 +140,13 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 8,
     elevation: 3,
+  },
+  cardImage: {
+    width: '100%',
+    height: 160,
+    borderRadius: 12,
+    marginBottom: 12,
+    backgroundColor: '#e5e5e5',
   },
   cardTitle: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
- allow admins to create auctions with numeric price validation and expose image previews in list responses
- add an admin workspace with a tab that toggles between auction creation and the buyer-facing feed
- surface uploaded auction images in the list and detail screens and expose a createAuction API client

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask_cors')*

------
https://chatgpt.com/codex/tasks/task_e_68f4e50025248330bef593fb07633ac2