### PR TITLE
Add dedicated admin and seller workspaces

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -16,6 +16,29 @@ from .utils import role_required
 admin_bp = Blueprint("admin", __name__)
 
 
+@admin_bp.get("/users")
+@jwt_required()
+@role_required(UserRole.ADMIN)
+def list_users():
+    users = User.query.order_by(User.created_at.desc()).all()
+    return (
+        jsonify(
+            [
+                {
+                    "id": str(user.id),
+                    "email": user.email,
+                    "username": user.username,
+                    "role": user.role.value,
+                    "status": user.status.value,
+                    "created_at": user.created_at.isoformat(),
+                }
+                for user in users
+            ]
+        ),
+        HTTPStatus.OK,
+    )
+
+
 @admin_bp.post("/users")
 @jwt_required()
 @role_required(UserRole.ADMIN)
@@ -63,26 +86,58 @@ def create_user():
 @admin_bp.patch("/users/<uuid:user_id>")
 @jwt_required()
 @role_required(UserRole.ADMIN)
-def update_user_status(user_id: uuid.UUID):
+def update_user(user_id: uuid.UUID):
     data = request.get_json(force=True)
-    status_value = data.get("status")
 
-    if status_value not in {item.value for item in UserStatus}:
-        abort(HTTPStatus.BAD_REQUEST, description="Invalid status")
+    if not data:
+        abort(HTTPStatus.BAD_REQUEST, description="No updates provided")
 
     user = User.query.filter_by(id=user_id).first()
     if user is None:
         abort(HTTPStatus.NOT_FOUND, description="User not found")
 
-    user.status = UserStatus(status_value)
+    updates: dict[str, str] = {}
+    audit_entries: list[AuditLog] = []
     actor_id = uuid.UUID(str(get_jwt_identity()))
-    audit = AuditLog(
-        actor_id=actor_id,
-        action="update_user_status",
-        target_type="user",
-        target_id=str(user.id),
-        meta={"status": status_value},
-    )
-    db.session.add(audit)
+
+    if "status" in data:
+        status_value = data.get("status")
+        if status_value not in {item.value for item in UserStatus}:
+            abort(HTTPStatus.BAD_REQUEST, description="Invalid status")
+        user.status = UserStatus(status_value)
+        updates["status"] = user.status.value
+        audit_entries.append(
+            AuditLog(
+                actor_id=actor_id,
+                action="update_user_status",
+                target_type="user",
+                target_id=str(user.id),
+                meta={"status": status_value},
+            )
+        )
+
+    if "role" in data:
+        role_value = data.get("role")
+        if role_value not in {UserRole.BUYER.value, UserRole.SELLER.value, UserRole.ADMIN.value}:
+            abort(HTTPStatus.BAD_REQUEST, description="Invalid role")
+        user.role = UserRole(role_value)
+        updates["role"] = user.role.value
+        audit_entries.append(
+            AuditLog(
+                actor_id=actor_id,
+                action="update_user_role",
+                target_type="user",
+                target_id=str(user.id),
+                meta={"role": role_value},
+            )
+        )
+
+    if not updates:
+        abort(HTTPStatus.BAD_REQUEST, description="No valid updates provided")
+
+    for audit in audit_entries:
+        db.session.add(audit)
     db.session.commit()
-    return jsonify({"id": str(user.id), "status": user.status.value})
+
+    response = {"id": str(user.id), **updates}
+    return jsonify(response)

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -7,6 +7,7 @@ import AuctionListScreen from './src/screens/AuctionListScreen';
 import LoginScreen from './src/screens/LoginScreen';
 import RegisterScreen from './src/screens/RegisterScreen';
 import AdminHomeScreen from './src/screens/AdminHomeScreen';
+import SellerHomeScreen from './src/screens/SellerHomeScreen';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
 
 const Stack = createNativeStackNavigator();
@@ -20,6 +21,15 @@ function RootNavigator() {
         role === 'admin' ? (
           <>
             <Stack.Screen name="Admin" component={AdminHomeScreen} options={{ headerShown: false }} />
+            <Stack.Screen
+              name="AuctionDetail"
+              component={AuctionDetailScreen}
+              options={{ title: 'Auction detail' }}
+            />
+          </>
+        ) : role === 'seller' ? (
+          <>
+            <Stack.Screen name="Seller" component={SellerHomeScreen} options={{ headerShown: false }} />
             <Stack.Screen
               name="AuctionDetail"
               component={AuctionDetailScreen}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -47,9 +47,20 @@ export async function login({ usernameOrEmail, password }) {
   });
 }
 
-export async function listAuctions({ status = 'active' } = {}) {
-  const query = `?status=${encodeURIComponent(status)}`;
-  return request(`/auctions${query}`);
+export async function listAuctions({ status = 'active', sort = 'fresh', scope, token } = {}) {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  if (sort) {
+    params.append('sort', sort);
+  }
+  if (scope) {
+    params.append('scope', scope);
+  }
+  const query = params.toString();
+  const suffix = query ? `?${query}` : '';
+  return request(`/auctions${suffix}`, { token });
 }
 
 export async function fetchAuction(auctionId) {
@@ -72,6 +83,61 @@ export async function createAuction(data, token) {
   });
 }
 
+export async function listMyAuctions({ status = 'all' } = {}, token) {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  const query = params.toString();
+  const suffix = query ? `?${query}` : '';
+  return request(`/auctions/mine${suffix}`, { token });
+}
+
+export async function listManageAuctions({ status = 'all' } = {}, token) {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  const query = params.toString();
+  const suffix = query ? `?${query}` : '';
+  return request(`/auctions/manage${suffix}`, { token });
+}
+
+export async function updateAuction(auctionId, data, token) {
+  return request(`/auctions/${auctionId}`, {
+    method: 'PATCH',
+    token,
+    body: data,
+  });
+}
+
+export async function deleteAuction(auctionId, token) {
+  return request(`/auctions/${auctionId}`, {
+    method: 'DELETE',
+    token,
+  });
+}
+
+export async function listUsers(token) {
+  return request('/admin/users', { token });
+}
+
+export async function createUser(data, token) {
+  return request('/admin/users', {
+    method: 'POST',
+    token,
+    body: data,
+  });
+}
+
+export async function updateUser(userId, data, token) {
+  return request(`/admin/users/${userId}`, {
+    method: 'PATCH',
+    token,
+    body: data,
+  });
+}
+
 export default {
   register,
   login,
@@ -79,4 +145,11 @@ export default {
   fetchAuction,
   placeBid,
   createAuction,
+  listMyAuctions,
+  listManageAuctions,
+  updateAuction,
+  deleteAuction,
+  listUsers,
+  createUser,
+  updateUser,
 };

--- a/frontend/src/components/AuctionManagementList.js
+++ b/frontend/src/components/AuctionManagementList.js
@@ -1,0 +1,397 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  deleteAuction,
+  fetchAuction,
+  listManageAuctions,
+  listMyAuctions,
+  updateAuction,
+} from '../api/client';
+
+const EMPTY_LIST_MESSAGE = {
+  admin: 'No auctions found.',
+  seller: "You have not created any auctions yet.",
+};
+
+function AuctionRow({ auction, onEditPress, onDeletePress, isDeleting }) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>{auction.title}</Text>
+        <Text style={styles.cardStatus}>{auction.status}</Text>
+      </View>
+      <View style={styles.cardRow}>
+        <Text style={styles.cardLabel}>Minimum price</Text>
+        <Text style={styles.cardValue}>
+          {auction.min_price} {auction.currency}
+        </Text>
+      </View>
+      {auction.end_at ? (
+        <Text style={styles.cardMeta}>Ends at {new Date(auction.end_at).toLocaleString()}</Text>
+      ) : null}
+      <View style={styles.cardActions}>
+        <Pressable
+          onPress={() => onEditPress(auction.id)}
+          style={({ pressed }) => [styles.actionButton, pressed && styles.actionButtonPressed]}
+        >
+          <Text style={styles.actionButtonLabel}>Edit</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => onDeletePress(auction.id)}
+          style={({ pressed }) => [styles.deleteButton, pressed && styles.actionButtonPressed]}
+          disabled={isDeleting}
+        >
+          <Text style={styles.deleteButtonLabel}>{isDeleting ? 'Deleting…' : 'Delete'}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export default function AuctionManagementList({ mode = 'seller', accessToken, refreshKey = 0 }) {
+  const [auctions, setAuctions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [editingId, setEditingId] = useState(null);
+  const [formValues, setFormValues] = useState({ title: '', description: '', min_price: '' });
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState(null);
+
+  const emptyMessage = EMPTY_LIST_MESSAGE[mode] || EMPTY_LIST_MESSAGE.seller;
+
+  const loadAuctions = useCallback(async () => {
+    setLoading(true);
+    try {
+      setError(null);
+      const loader = mode === 'admin' ? listManageAuctions : listMyAuctions;
+      const data = await loader({ status: 'all' }, accessToken);
+      setAuctions(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [mode, accessToken]);
+
+  useEffect(() => {
+    loadAuctions();
+  }, [loadAuctions, refreshKey]);
+
+  const handleEditPress = useCallback(
+    async (auctionId) => {
+      try {
+        const detail = await fetchAuction(auctionId);
+        setEditingId(auctionId);
+        setFormValues({
+          title: detail.title || '',
+          description: detail.description || '',
+          min_price: String(detail.min_price ?? ''),
+        });
+      } catch (err) {
+        Alert.alert('Unable to load auction', err.message);
+      }
+    },
+    [],
+  );
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setFormValues({ title: '', description: '', min_price: '' });
+  };
+
+  const handleSave = async () => {
+    if (!editingId) {
+      return;
+    }
+    if (!formValues.title.trim()) {
+      Alert.alert('Missing title', 'Please provide a title for the auction.');
+      return;
+    }
+    const numericPrice = Number(formValues.min_price);
+    if (!formValues.min_price || Number.isNaN(numericPrice) || numericPrice <= 0) {
+      Alert.alert('Invalid price', 'Enter a minimum price greater than 0.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await updateAuction(
+        editingId,
+        {
+          title: formValues.title.trim(),
+          description: formValues.description.trim() || formValues.title.trim(),
+          min_price: numericPrice,
+        },
+        accessToken,
+      );
+      Alert.alert('Auction updated', 'Changes have been saved.');
+      cancelEdit();
+      await loadAuctions();
+    } catch (err) {
+      Alert.alert('Update failed', err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (auctionId) => {
+    Alert.alert('Delete auction', 'Are you sure you want to delete this auction?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          setDeletingId(auctionId);
+          try {
+            await deleteAuction(auctionId, accessToken);
+            await loadAuctions();
+          } catch (err) {
+            Alert.alert('Delete failed', err.message);
+          } finally {
+            setDeletingId(null);
+          }
+        },
+      },
+    ]);
+  };
+
+  const renderItem = useCallback(
+    ({ item }) => (
+      <AuctionRow
+        auction={item}
+        onEditPress={handleEditPress}
+        onDeletePress={handleDelete}
+        isDeleting={deletingId === item.id}
+      />
+    ),
+    [handleEditPress, handleDelete, deletingId],
+  );
+
+  const keyExtractor = useCallback((item) => item.id, []);
+
+  const content = useMemo(() => {
+    if (loading) {
+      return <Text style={styles.helperText}>Loading auctions…</Text>;
+    }
+    if (error) {
+      return <Text style={styles.errorText}>{error}</Text>;
+    }
+    if (!auctions.length) {
+      return <Text style={styles.helperText}>{emptyMessage}</Text>;
+    }
+    return (
+      <FlatList
+        data={auctions}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        contentContainerStyle={styles.listContent}
+      />
+    );
+  }, [auctions, emptyMessage, error, keyExtractor, loading, renderItem]);
+
+  return (
+    <View style={styles.container}>
+      {content}
+      {editingId ? (
+        <View style={styles.editCard}>
+          <Text style={styles.editTitle}>Edit auction</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Title"
+            value={formValues.title}
+            onChangeText={(value) => setFormValues((current) => ({ ...current, title: value }))}
+          />
+          <TextInput
+            style={[styles.input, styles.multiline]}
+            placeholder="Description"
+            multiline
+            value={formValues.description}
+            onChangeText={(value) => setFormValues((current) => ({ ...current, description: value }))}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Minimum price"
+            keyboardType="decimal-pad"
+            value={formValues.min_price}
+            onChangeText={(value) => setFormValues((current) => ({ ...current, min_price: value }))}
+          />
+          <View style={styles.editActions}>
+            <Pressable
+              onPress={cancelEdit}
+              style={({ pressed }) => [styles.cancelButton, pressed && styles.actionButtonPressed]}
+              disabled={saving}
+            >
+              <Text style={styles.cancelLabel}>Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleSave}
+              style={({ pressed }) => [styles.saveButton, pressed && styles.saveButtonPressed]}
+              disabled={saving}
+            >
+              <Text style={styles.saveLabel}>{saving ? 'Saving…' : 'Save changes'}</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+  },
+  helperText: {
+    textAlign: 'center',
+    color: '#4a4a4a',
+    marginTop: 32,
+  },
+  errorText: {
+    textAlign: 'center',
+    color: '#d92d20',
+    marginTop: 16,
+  },
+  listContent: {
+    paddingBottom: 24,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 14,
+    padding: 16,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    flex: 1,
+    marginRight: 12,
+  },
+  cardStatus: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#0f62fe',
+    textTransform: 'uppercase',
+  },
+  cardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  cardLabel: {
+    color: '#6f6f6f',
+    fontWeight: '500',
+  },
+  cardValue: {
+    color: '#0f62fe',
+    fontWeight: '600',
+  },
+  cardMeta: {
+    color: '#6f6f6f',
+    fontSize: 12,
+    marginBottom: 12,
+  },
+  cardActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 12,
+  },
+  actionButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#eef2ff',
+  },
+  actionButtonPressed: {
+    opacity: 0.7,
+  },
+  actionButtonLabel: {
+    color: '#0f62fe',
+    fontWeight: '600',
+  },
+  deleteButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#ffe5e5',
+  },
+  deleteButtonLabel: {
+    color: '#d92d20',
+    fontWeight: '600',
+  },
+  editCard: {
+    marginTop: 16,
+    backgroundColor: '#fff',
+    borderRadius: 14,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 10,
+    elevation: 4,
+  },
+  editTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d0d5dd',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 12,
+    fontSize: 16,
+  },
+  multiline: {
+    minHeight: 90,
+    textAlignVertical: 'top',
+  },
+  editActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 12,
+  },
+  cancelButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: '#eef2ff',
+  },
+  cancelLabel: {
+    color: '#4a4a4a',
+    fontWeight: '600',
+  },
+  saveButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: '#0f62fe',
+  },
+  saveButtonPressed: {
+    opacity: 0.8,
+  },
+  saveLabel: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/components/UserManagementSection.js
+++ b/frontend/src/components/UserManagementSection.js
@@ -1,0 +1,336 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { createUser, listUsers, updateUser } from '../api/client';
+
+const ROLE_OPTIONS = [
+  { label: 'Buyer', value: 'buyer' },
+  { label: 'Seller', value: 'seller' },
+];
+
+export default function UserManagementSection({ accessToken }) {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('buyer');
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [updatingUserId, setUpdatingUserId] = useState(null);
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      setError(null);
+      const data = await listUsers(accessToken);
+      setUsers(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    loadUsers();
+  }, [loadUsers]);
+
+  const resetForm = () => {
+    setEmail('');
+    setUsername('');
+    setPassword('');
+    setRole('buyer');
+  };
+
+  const handleCreateUser = async () => {
+    if (!email.trim() || !username.trim() || !password.trim()) {
+      Alert.alert('Missing fields', 'Email, username and password are required.');
+      return;
+    }
+    if (password.length < 12) {
+      Alert.alert('Weak password', 'Password must be at least 12 characters long.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await createUser(
+        {
+          email: email.trim(),
+          username: username.trim(),
+          password,
+          role,
+        },
+        accessToken,
+      );
+      Alert.alert('User created', 'The user account has been created successfully.');
+      resetForm();
+      await loadUsers();
+    } catch (err) {
+      Alert.alert('Creation failed', err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRoleChange = async (userId, nextRole) => {
+    if (updatingUserId) {
+      return;
+    }
+    setUpdatingUserId(userId);
+    try {
+      await updateUser(userId, { role: nextRole }, accessToken);
+      await loadUsers();
+    } catch (err) {
+      Alert.alert('Update failed', err.message);
+    } finally {
+      setUpdatingUserId(null);
+    }
+  };
+
+  const renderUserCards = () => {
+    if (loading) {
+      return <Text style={styles.helperText}>Loading users…</Text>;
+    }
+    if (error) {
+      return <Text style={styles.errorText}>{error}</Text>;
+    }
+    if (!users.length) {
+      return <Text style={styles.helperText}>No users found.</Text>;
+    }
+
+    return users.map((user) => {
+      const isBusy = updatingUserId === user.id;
+      return (
+        <View key={user.id} style={styles.userCard}>
+          <View style={styles.userHeader}>
+            <Text style={styles.userName}>{user.username}</Text>
+            <Text style={styles.userRole}>{user.role}</Text>
+          </View>
+          <Text style={styles.userEmail}>{user.email}</Text>
+          <Text style={styles.userMeta}>Status: {user.status}</Text>
+          <View style={styles.roleButtons}>
+            {ROLE_OPTIONS.map((option) => {
+              const isActive = user.role === option.value;
+              return (
+                <Pressable
+                  key={option.value}
+                  onPress={() => handleRoleChange(user.id, option.value)}
+                  style={({ pressed }) => [
+                    styles.roleButton,
+                    isActive && styles.roleButtonActive,
+                    pressed && styles.roleButtonPressed,
+                  ]}
+                  disabled={isActive || isBusy}
+                >
+                  <Text style={[styles.roleButtonLabel, isActive && styles.roleButtonLabelActive]}>
+                    {isBusy && !isActive ? 'Updating…' : option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      );
+    });
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Create new user</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Username"
+          autoCapitalize="none"
+          value={username}
+          onChangeText={setUsername}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Password"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+        <View style={styles.roleSelector}>
+          {ROLE_OPTIONS.map((option) => {
+            const isActive = role === option.value;
+            return (
+              <Pressable
+                key={option.value}
+                onPress={() => setRole(option.value)}
+                style={({ pressed }) => [
+                  styles.rolePill,
+                  isActive && styles.rolePillActive,
+                  pressed && styles.roleButtonPressed,
+                ]}
+              >
+                <Text style={[styles.rolePillLabel, isActive && styles.rolePillLabelActive]}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        <Pressable
+          onPress={handleCreateUser}
+          style={({ pressed }) => [styles.submitButton, pressed && styles.submitButtonPressed]}
+          disabled={isSubmitting}
+        >
+          <Text style={styles.submitLabel}>{isSubmitting ? 'Creating…' : 'Create user'}</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.listCard}>
+        <Text style={styles.cardTitle}>Existing users</Text>
+        {renderUserCards()}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+    paddingBottom: 32,
+    gap: 16,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    elevation: 4,
+  },
+  listCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    elevation: 4,
+  },
+  cardTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d0d5dd',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 12,
+    fontSize: 16,
+  },
+  roleSelector: {
+    flexDirection: 'row',
+    gap: 12,
+    marginBottom: 12,
+  },
+  rolePill: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 999,
+    backgroundColor: '#eef2ff',
+  },
+  rolePillActive: {
+    backgroundColor: '#0f62fe',
+  },
+  rolePillLabel: {
+    color: '#0f62fe',
+    fontWeight: '600',
+  },
+  rolePillLabelActive: {
+    color: '#fff',
+  },
+  submitButton: {
+    backgroundColor: '#0f62fe',
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  submitButtonPressed: {
+    opacity: 0.8,
+  },
+  submitLabel: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  helperText: {
+    color: '#4a4a4a',
+    marginTop: 12,
+  },
+  errorText: {
+    color: '#d92d20',
+    marginTop: 12,
+  },
+  userCard: {
+    marginBottom: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e4e7ec',
+    borderRadius: 12,
+  },
+  userHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  userName: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  userRole: {
+    fontWeight: '600',
+    color: '#0f62fe',
+  },
+  userEmail: {
+    color: '#4a4a4a',
+    marginBottom: 4,
+  },
+  userMeta: {
+    color: '#6f6f6f',
+    marginBottom: 12,
+  },
+  roleButtons: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  roleButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#d0d5dd',
+    backgroundColor: '#fff',
+  },
+  roleButtonActive: {
+    backgroundColor: '#0f62fe',
+    borderColor: '#0f62fe',
+  },
+  roleButtonLabel: {
+    color: '#0f62fe',
+    fontWeight: '600',
+  },
+  roleButtonLabelActive: {
+    color: '#fff',
+  },
+  roleButtonPressed: {
+    opacity: 0.8,
+  },
+});

--- a/frontend/src/screens/SellerHomeScreen.js
+++ b/frontend/src/screens/SellerHomeScreen.js
@@ -2,29 +2,34 @@ import React, { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useAuth } from '../context/AuthContext';
+import AdminNewAuctionForm from '../components/AdminNewAuctionForm';
 import AuctionManagementList from '../components/AuctionManagementList';
-import UserManagementSection from '../components/UserManagementSection';
 
-export default function AdminHomeScreen() {
+export default function SellerHomeScreen() {
   const { logout, accessToken } = useAuth();
-  const [activeTab, setActiveTab] = useState('users');
+  const [activeTab, setActiveTab] = useState('create');
   const [refreshKey, setRefreshKey] = useState(0);
 
   useFocusEffect(
     useCallback(() => {
-      setActiveTab('users');
+      setActiveTab('create');
       setRefreshKey((current) => current + 1);
     }, []),
   );
 
-  const showUsers = activeTab === 'users';
+  const handleCreated = () => {
+    setRefreshKey((current) => current + 1);
+    setActiveTab('manage');
+  };
+
+  const showCreate = activeTab === 'create';
 
   return (
     <View style={styles.container}>
       <View style={styles.header}>
         <View style={styles.headerText}>
-          <Text style={styles.title}>Admin control center</Text>
-          <Text style={styles.subtitle}>Manage platform users and oversee auctions</Text>
+          <Text style={styles.title}>Seller workspace</Text>
+          <Text style={styles.subtitle}>Publish new auctions and manage your listings</Text>
         </View>
         <Pressable onPress={logout} style={styles.logoutButton}>
           <Text style={styles.logout}>Log out</Text>
@@ -33,24 +38,24 @@ export default function AdminHomeScreen() {
 
       <View style={styles.tabBar}>
         <Pressable
-          onPress={() => setActiveTab('users')}
-          style={[styles.tabButton, showUsers && styles.tabButtonActive]}
+          onPress={() => setActiveTab('create')}
+          style={[styles.tabButton, showCreate && styles.tabButtonActive]}
         >
-          <Text style={[styles.tabLabel, showUsers && styles.tabLabelActive]}>Users</Text>
+          <Text style={[styles.tabLabel, showCreate && styles.tabLabelActive]}>Create auction</Text>
         </Pressable>
         <Pressable
-          onPress={() => setActiveTab('auctions')}
-          style={[styles.tabButton, !showUsers && styles.tabButtonActive]}
+          onPress={() => setActiveTab('manage')}
+          style={[styles.tabButton, !showCreate && styles.tabButtonActive]}
         >
-          <Text style={[styles.tabLabel, !showUsers && styles.tabLabelActive]}>Auctions</Text>
+          <Text style={[styles.tabLabel, !showCreate && styles.tabLabelActive]}>My auctions</Text>
         </Pressable>
       </View>
 
       <View style={styles.content}>
-        {showUsers ? (
-          <UserManagementSection accessToken={accessToken} />
+        {showCreate ? (
+          <AdminNewAuctionForm onCreated={handleCreated} />
         ) : (
-          <AuctionManagementList mode="admin" accessToken={accessToken} refreshKey={refreshKey} />
+          <AuctionManagementList mode="seller" accessToken={accessToken} refreshKey={refreshKey} />
         )}
       </View>
     </View>


### PR DESCRIPTION
## Summary
- add administrative endpoints for listing users, updating roles, and managing auctions
- expand the auctions API with dedicated seller/admin listings and wire them to the frontend client
- build new admin and seller home screens with user management and auction editing capabilities

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask_cors')*

------
https://chatgpt.com/codex/tasks/task_e_68f4ec074aec8330a5173c4da15de58a