### PR TITLE
Fix auction image preview fallback and allow admin role assignment

### DIFF
--- a/frontend/src/components/UserManagementSection.js
+++ b/frontend/src/components/UserManagementSection.js
@@ -5,6 +5,7 @@ import { createUser, listUsers, updateUser } from '../api/client';
 const ROLE_OPTIONS = [
   { label: 'Buyer', value: 'buyer' },
   { label: 'Seller', value: 'seller' },
+  { label: 'Admin', value: 'admin' },
 ];
 
 export default function UserManagementSection({ accessToken }) {

--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -42,7 +42,10 @@ export default function AuctionDetailScreen({ route }) {
     try {
       const data = await fetchAuction(id);
       setAuction(data);
-      if (data.image_urls && data.image_urls.length > 0) {
+      const hasImages =
+        (Array.isArray(data.image_urls) && data.image_urls.length > 0) ||
+        (Array.isArray(data.images) && data.images.length > 0);
+      if (hasImages) {
         setActiveImageIndex(0);
       }
     } catch (error) {
@@ -90,7 +93,10 @@ export default function AuctionDetailScreen({ route }) {
   const isBuyer = role === 'buyer';
   const canBid = Boolean(accessToken && isBuyer);
 
-  const imageUrls = auction.image_urls || [];
+  const imageUrls =
+    (Array.isArray(auction.image_urls) && auction.image_urls) ||
+    (Array.isArray(auction.images) && auction.images) ||
+    [];
   const heroImage = imageUrls[activeImageIndex] || imageUrls[0];
 
   return (

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -15,7 +15,10 @@ import { useAuth } from '../context/AuthContext';
 
 function AuctionCard({ auction, onPress }) {
   const bestBid = auction.best_bid;
-  const previewImage = auction.image_urls && auction.image_urls[0];
+  const previewImage =
+    (Array.isArray(auction.image_urls) && auction.image_urls[0]) ||
+    (Array.isArray(auction.images) && auction.images[0]) ||
+    null;
   return (
     <Pressable style={styles.card} onPress={onPress}>
       {previewImage ? (


### PR DESCRIPTION
## Summary
- ensure auction previews and detail views fall back to alternative image fields so thumbnails render again
- allow administrators to assign the admin role when creating or updating users

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4f5c2309c8330a56abbde875d9a40