### PR TITLE
Harden backend validation and bidding logic

### DIFF
--- a/backend/app/routes/utils.py
+++ b/backend/app/routes/utils.py
@@ -9,7 +9,6 @@ from flask import abort
 from flask_jwt_extended import get_jwt, get_jwt_identity
 
 from ..models import User
-
 from ..models import UserRole
 
 F = TypeVar("F", bound=Callable[..., object])
@@ -36,7 +35,12 @@ def get_current_user() -> User:
     """Return the authenticated user from the JWT identity."""
 
     identity = get_jwt_identity()
-    user = User.query.filter_by(id=uuid.UUID(str(identity))).first()
+    try:
+        user_uuid = uuid.UUID(str(identity))
+    except (TypeError, ValueError):
+        abort(401, description="Unknown user")
+
+    user = User.query.filter_by(id=user_uuid).first()
     if user is None:
         abort(401, description="Unknown user")
     if not user.is_active():


### PR DESCRIPTION
## Summary
- validate admin and public registration inputs, normalize emails, and enforce strong usernames/passwords
- harden auction create/update flows by sanitizing text fields, enforcing ISO currency codes, and using decimal price parsing
- prevent malformed bids and JWT identities from returning 500 errors by tightening numeric handling and identity parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f4fcb2b0bc83308923b82b3b9c3a2a