### PR TITLE
Add auction descriptions and image management

### DIFF
--- a/backend/app/routes/auctions.py
+++ b/backend/app/routes/auctions.py
@@ -127,8 +127,7 @@ def create_auction():
     user = get_current_user()
     data = request.get_json(force=True)
     title = _sanitize_text(data.get("title"), "title")
-    description_raw = data.get("description")
-    description = _sanitize_text(description_raw, "description", allow_empty=True) or title
+    description = _sanitize_text(data.get("description"), "description")
     min_price_value = _parse_price(data.get("min_price"))
     currency = _normalize_currency(data.get("currency", "EUR"))
     images = _normalize_images(data.get("images", []))
@@ -222,10 +221,7 @@ def update_auction(auction_id: uuid.UUID):
         updates_applied = True
 
     if "description" in data:
-        description = _sanitize_text(
-            data.get("description"), "description", allow_empty=True
-        )
-        auction.description = description or auction.title
+        auction.description = _sanitize_text(data.get("description"), "description")
         updates_applied = True
 
     if "min_price" in data:
@@ -274,6 +270,7 @@ def serialize_auction_preview(auction: Auction) -> dict:
     return {
         "id": str(auction.id),
         "title": auction.title,
+        "description": auction.description,
         "min_price": float(auction.min_price),
         "currency": auction.currency,
         "status": auction.status.value,

--- a/frontend/src/components/AdminNewAuctionForm.js
+++ b/frontend/src/components/AdminNewAuctionForm.js
@@ -19,6 +19,7 @@ export default function AdminNewAuctionForm({ onCreated }) {
   const { accessToken } = useAuth();
   const [title, setTitle] = useState('');
   const [minPrice, setMinPrice] = useState('');
+  const [description, setDescription] = useState('');
   const [selectedImages, setSelectedImages] = useState([]);
   const [isSubmitting, setSubmitting] = useState(false);
 
@@ -79,8 +80,16 @@ export default function AdminNewAuctionForm({ onCreated }) {
   };
 
   const handleCreateAuction = async () => {
-    if (!title.trim()) {
+    const trimmedTitle = title.trim();
+    const trimmedDescription = description.trim();
+
+    if (!trimmedTitle) {
       Alert.alert('Missing title', 'Please provide a descriptive auction name.');
+      return;
+    }
+
+    if (!trimmedDescription) {
+      Alert.alert('Missing description', 'Describe the vehicle to help buyers.');
       return;
     }
 
@@ -94,9 +103,9 @@ export default function AdminNewAuctionForm({ onCreated }) {
     try {
       await createAuction(
         {
-          title: title.trim(),
+          title: trimmedTitle,
+          description: trimmedDescription,
           min_price: numericMinPrice,
-          description: title.trim(),
           currency: 'EUR',
           images: selectedImages.map((item) => item.dataUrl),
         },
@@ -104,6 +113,7 @@ export default function AdminNewAuctionForm({ onCreated }) {
       );
       setTitle('');
       setMinPrice('');
+      setDescription('');
       setSelectedImages([]);
       Alert.alert('Auction created', 'The auction has been published successfully.');
       if (onCreated) {
@@ -135,6 +145,18 @@ export default function AdminNewAuctionForm({ onCreated }) {
             onChangeText={setTitle}
             autoCapitalize="words"
             returnKeyType="next"
+          />
+        </View>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Description</Text>
+          <TextInput
+            style={[styles.input, styles.multiline]}
+            placeholder="Highlight the vehicle condition, mileage, upgrades, etc."
+            value={description}
+            onChangeText={setDescription}
+            multiline
+            textAlignVertical="top"
           />
         </View>
 
@@ -227,6 +249,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#d0d5dd',
     fontSize: 16,
+  },
+  multiline: {
+    minHeight: 120,
+    textAlignVertical: 'top',
   },
   uploadButton: {
     borderWidth: 1,

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -25,6 +25,11 @@ function AuctionCard({ auction, onPress }) {
         <Image source={{ uri: previewImage }} style={styles.cardImage} resizeMode="cover" />
       ) : null}
       <Text style={styles.cardTitle}>{auction.title}</Text>
+      {auction.description ? (
+        <Text style={styles.cardDescription} numberOfLines={2}>
+          {auction.description}
+        </Text>
+      ) : null}
       <View style={styles.cardRow}>
         <Text style={styles.cardLabel}>Minimum:</Text>
         <Text style={styles.cardValue}>
@@ -154,6 +159,10 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontSize: 18,
     fontWeight: '600',
+    marginBottom: 6,
+  },
+  cardDescription: {
+    color: '#4a4a4a',
     marginBottom: 12,
   },
   cardRow: {


### PR DESCRIPTION
## Summary
- require and expose auction descriptions in API responses and listings
- add description field to auction creation and editing forms
- enable sellers to add or remove images while editing auctions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f4ffd08e3083308ffa387107482756