### PR TITLE
Require carte grise image for auctions

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -87,6 +87,7 @@ class Auction(BaseModel):
     min_price: Mapped[float] = mapped_column(db.Numeric(10, 2), nullable=False)
     currency: Mapped[str] = mapped_column(db.String(3), default="EUR", nullable=False)
     image_urls: Mapped[list[str]] = mapped_column(db.JSON, default=list)
+    carte_grise_image_url: Mapped[str | None] = mapped_column(db.Text)
     status: Mapped[AuctionStatus] = mapped_column(
         db.Enum(AuctionStatus), default=AuctionStatus.DRAFT, nullable=False
     )

--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -98,6 +98,7 @@ export default function AuctionDetailScreen({ route }) {
     (Array.isArray(auction.images) && auction.images) ||
     [];
   const heroImage = imageUrls[activeImageIndex] || imageUrls[0];
+  const carteGriseImage = auction.carte_grise_image_url;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -120,6 +121,19 @@ export default function AuctionDetailScreen({ route }) {
               </Pressable>
             );
           })}
+        </View>
+      ) : null}
+      {carteGriseImage ? (
+        <View style={styles.documentSection}>
+          <Text style={styles.sectionTitle}>Carte grise</Text>
+          <Text style={styles.documentHelper}>
+            Seller provided the vehicle registration document.
+          </Text>
+          <Image
+            source={{ uri: carteGriseImage }}
+            style={styles.documentImage}
+            resizeMode="cover"
+          />
         </View>
       ) : null}
       <Text style={styles.meta}>Minimum price: {auction.min_price} {auction.currency}</Text>
@@ -272,6 +286,20 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: '600',
     fontSize: 16,
+  },
+  documentSection: {
+    marginTop: 12,
+    marginBottom: 16,
+  },
+  documentHelper: {
+    color: '#4a4a4a',
+  },
+  documentImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 12,
+    backgroundColor: '#e5e5e5',
+    marginTop: 12,
   },
   info: {
     marginTop: 24,


### PR DESCRIPTION
## Summary
- require a carte grise image when creating or updating auctions and expose it in API payloads
- persist the carte grise image on auctions and adjust integration tests to cover the new validation
- add dedicated upload flows and previews for the carte grise photo across seller creation, editing, and buyer detail views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fcaef0294c8330b9537bd3f42b96ed