### PR TITLE
Ensure carte grise column exists in SQLite

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -87,6 +87,7 @@ class Auction(BaseModel):
     min_price: Mapped[float] = mapped_column(db.Numeric(10, 2), nullable=False)
     currency: Mapped[str] = mapped_column(db.String(3), default="EUR", nullable=False)
     image_urls: Mapped[list[str]] = mapped_column(db.JSON, default=list)
+    carte_grise_image_url: Mapped[str | None] = mapped_column(db.Text)
     status: Mapped[AuctionStatus] = mapped_column(
         db.Enum(AuctionStatus), default=AuctionStatus.DRAFT, nullable=False
     )

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -1,0 +1,22 @@
+"""Tests for database schema compatibility helpers."""
+
+from sqlalchemy import create_engine, inspect, text
+
+from app import _ensure_carte_grise_column
+
+
+def test_ensure_carte_grise_column_adds_missing_column(tmp_path):
+    """The helper should add the carte grise column to legacy databases."""
+
+    db_path = tmp_path / "legacy.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE auctions (id INTEGER PRIMARY KEY)"))
+
+    _ensure_carte_grise_column(engine)
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("auctions")}
+
+    assert "carte_grise_image_url" in columns

--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -98,6 +98,7 @@ export default function AuctionDetailScreen({ route }) {
     (Array.isArray(auction.images) && auction.images) ||
     [];
   const heroImage = imageUrls[activeImageIndex] || imageUrls[0];
+  const carteGriseImage = auction.carte_grise_image_url;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -120,6 +121,19 @@ export default function AuctionDetailScreen({ route }) {
               </Pressable>
             );
           })}
+        </View>
+      ) : null}
+      {carteGriseImage ? (
+        <View style={styles.documentSection}>
+          <Text style={styles.sectionTitle}>Carte grise</Text>
+          <Text style={styles.documentHelper}>
+            Seller provided the vehicle registration document.
+          </Text>
+          <Image
+            source={{ uri: carteGriseImage }}
+            style={styles.documentImage}
+            resizeMode="cover"
+          />
         </View>
       ) : null}
       <Text style={styles.meta}>Minimum price: {auction.min_price} {auction.currency}</Text>
@@ -272,6 +286,20 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: '600',
     fontSize: 16,
+  },
+  documentSection: {
+    marginTop: 12,
+    marginBottom: 16,
+  },
+  documentHelper: {
+    color: '#4a4a4a',
+  },
+  documentImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 12,
+    backgroundColor: '#e5e5e5',
+    marginTop: 12,
   },
   info: {
     marginTop: 24,


### PR DESCRIPTION
## Summary
- add a schema helper that ensures the auctions table includes the carte grise image column for existing SQLite databases
- invoke the helper during application startup so legacy databases pick up the new column requirement
- cover the schema adjustment with a regression test that simulates upgrading a legacy SQLite database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fcaef0294c8330b9537bd3f42b96ed