### PR TITLE
Display highest bidder information in seller auction list

### DIFF
--- a/backend/app/routes/bids.py
+++ b/backend/app/routes/bids.py
@@ -73,6 +73,7 @@ def place_bid(auction_id: uuid.UUID):
     bid = Bid(
         auction_id=auction_id,
         buyer_id=user.id,
+        buyer=user,
         amount=amount_decimal,
         idx_per_buyer=existing_count + 1,
     )
@@ -90,6 +91,7 @@ def serialize_bid(bid: Bid) -> dict:
         "id": str(bid.id),
         "amount": float(bid.amount),
         "buyer_id": str(bid.buyer_id),
+        "buyer_username": bid.buyer.username if bid.buyer else None,
         "created_at": bid.created_at.isoformat(),
     }
 

--- a/backend/tests/test_auction_flow.py
+++ b/backend/tests/test_auction_flow.py
@@ -94,11 +94,13 @@ def test_seller_can_create_and_buyer_can_bid(client):
     assert bid_response.status_code == 201
     bid_data = bid_response.get_json()["bid"]
     assert bid_data["amount"] == 51000.0
+    assert bid_data["buyer_username"] == "buyer1"
 
     list_response = client.get("/auctions")
     assert list_response.status_code == 200
     listings = list_response.get_json()
     assert listings[0]["best_bid"]["amount"] == 51000.0
+    assert listings[0]["best_bid"]["buyer_username"] == "buyer1"
 
     notifications = Notification.query.all()
     assert any(n.type == NotificationType.NEW_AUCTION for n in notifications)


### PR DESCRIPTION
## Summary
- include the bidder username in auction and bid payloads and eager-load bidder data
- surface the highest bidder in the seller management list and highlight expired auctions with a winner
- extend backend tests to cover the new bidder metadata

## Testing
- pytest backend

------
https://chatgpt.com/codex/tasks/task_e_68fcb70920e8833087d31a24707fae03