### PR TITLE
Fix logout flow for buyer and seller dashboards

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
@@ -9,11 +9,18 @@ import RegisterScreen from './src/screens/RegisterScreen';
 import AdminHomeScreen from './src/screens/AdminHomeScreen';
 import SellerHomeScreen from './src/screens/SellerHomeScreen';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
+import { navigationRef, resetToLogin } from './src/navigation/navigationRef';
 
 const Stack = createNativeStackNavigator();
 
 function RootNavigator() {
   const { isAuthenticated, role } = useAuth();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      resetToLogin();
+    }
+  }, [isAuthenticated]);
 
   return (
     <Stack.Navigator key={isAuthenticated ? 'app' : 'auth'}>
@@ -59,7 +66,7 @@ function RootNavigator() {
 export default function App() {
   return (
     <AuthProvider>
-      <NavigationContainer>
+      <NavigationContainer ref={navigationRef}>
         <StatusBar style="dark" />
         <RootNavigator />
       </NavigationContainer>

--- a/frontend/src/navigation/navigationRef.js
+++ b/frontend/src/navigation/navigationRef.js
@@ -1,0 +1,14 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+export const navigationRef = createNavigationContainerRef();
+
+export function resetToLogin() {
+  if (!navigationRef.isReady()) {
+    return;
+  }
+
+  navigationRef.resetRoot({
+    index: 0,
+    routes: [{ name: 'Login' }],
+  });
+}

--- a/frontend/src/screens/AdminHomeScreen.js
+++ b/frontend/src/screens/AdminHomeScreen.js
@@ -10,6 +10,10 @@ export default function AdminHomeScreen() {
   const [activeTab, setActiveTab] = useState('users');
   const [refreshKey, setRefreshKey] = useState(0);
 
+  const handleLogout = useCallback(() => {
+    logout();
+  }, [logout]);
+
   useFocusEffect(
     useCallback(() => {
       setActiveTab('users');
@@ -26,7 +30,7 @@ export default function AdminHomeScreen() {
           <Text style={styles.title}>Admin control center</Text>
           <Text style={styles.subtitle}>Manage platform users and oversee auctions</Text>
         </View>
-        <Pressable onPress={logout} style={styles.logoutButton}>
+        <Pressable onPress={handleLogout} style={styles.logoutButton}>
           <Text style={styles.logout}>Log out</Text>
         </Pressable>
       </View>

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -82,6 +82,10 @@ export default function AuctionListScreen({ navigation }) {
   const [error, setError] = useState(null);
   const [activeTabKey, setActiveTabKey] = useState('all');
 
+  const handleLogout = useCallback(() => {
+    logout();
+  }, [logout]);
+
   const currentTab = useMemo(
     () => TABS.find((tab) => tab.key === activeTabKey) || TABS[0],
     [activeTabKey],
@@ -145,7 +149,7 @@ export default function AuctionListScreen({ navigation }) {
     <View style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>Live auctions</Text>
-        <Pressable onPress={logout}>
+        <Pressable onPress={handleLogout}>
           <Text style={styles.logout}>Log out</Text>
         </Pressable>
       </View>

--- a/frontend/src/screens/SellerHomeScreen.js
+++ b/frontend/src/screens/SellerHomeScreen.js
@@ -10,6 +10,10 @@ export default function SellerHomeScreen() {
   const [activeTab, setActiveTab] = useState('create');
   const [refreshKey, setRefreshKey] = useState(0);
 
+  const handleLogout = useCallback(() => {
+    logout();
+  }, [logout]);
+
   useFocusEffect(
     useCallback(() => {
       setActiveTab('create');
@@ -31,7 +35,7 @@ export default function SellerHomeScreen() {
           <Text style={styles.title}>Seller workspace</Text>
           <Text style={styles.subtitle}>Publish new auctions and manage your listings</Text>
         </View>
-        <Pressable onPress={logout} style={styles.logoutButton}>
+        <Pressable onPress={handleLogout} style={styles.logoutButton}>
           <Text style={styles.logout}>Log out</Text>
         </Pressable>
       </View>


### PR DESCRIPTION
## Summary
- ensure navigation resets to the login screen when authentication ends
- share a navigation ref so buyer and seller logout buttons correctly return to auth flow
- wrap logout button handlers in the role-specific screens to call the shared logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcbb5a41a08330b6676ba30005fe56