### PR TITLE
Ensure buyer logout resets navigation

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
@@ -9,11 +9,18 @@ import RegisterScreen from './src/screens/RegisterScreen';
 import AdminHomeScreen from './src/screens/AdminHomeScreen';
 import SellerHomeScreen from './src/screens/SellerHomeScreen';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
+import { navigationRef, resetToLogin } from './src/navigation/navigationRef';
 
 const Stack = createNativeStackNavigator();
 
 function RootNavigator() {
   const { isAuthenticated, role } = useAuth();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      resetToLogin();
+    }
+  }, [isAuthenticated]);
 
   return (
     <Stack.Navigator key={isAuthenticated ? 'app' : 'auth'}>
@@ -59,7 +66,7 @@ function RootNavigator() {
 export default function App() {
   return (
     <AuthProvider>
-      <NavigationContainer>
+      <NavigationContainer ref={navigationRef}>
         <StatusBar style="dark" />
         <RootNavigator />
       </NavigationContainer>

--- a/frontend/src/hooks/useLogoutHandler.js
+++ b/frontend/src/hooks/useLogoutHandler.js
@@ -1,0 +1,9 @@
+import { useCallback } from 'react';
+import { resetToLogin } from '../navigation/navigationRef';
+
+export default function useLogoutHandler(logout) {
+  return useCallback(() => {
+    logout();
+    resetToLogin();
+  }, [logout]);
+}

--- a/frontend/src/navigation/navigationRef.js
+++ b/frontend/src/navigation/navigationRef.js
@@ -1,0 +1,14 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+export const navigationRef = createNavigationContainerRef();
+
+export function resetToLogin() {
+  if (!navigationRef.isReady()) {
+    return;
+  }
+
+  navigationRef.resetRoot({
+    index: 0,
+    routes: [{ name: 'Login' }],
+  });
+}

--- a/frontend/src/screens/AdminHomeScreen.js
+++ b/frontend/src/screens/AdminHomeScreen.js
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useAuth } from '../context/AuthContext';
+import useLogoutHandler from '../hooks/useLogoutHandler';
 import AuctionManagementList from '../components/AuctionManagementList';
 import UserManagementSection from '../components/UserManagementSection';
 
@@ -9,6 +10,8 @@ export default function AdminHomeScreen() {
   const { logout, accessToken } = useAuth();
   const [activeTab, setActiveTab] = useState('users');
   const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleLogout = useLogoutHandler(logout);
 
   useFocusEffect(
     useCallback(() => {
@@ -26,7 +29,7 @@ export default function AdminHomeScreen() {
           <Text style={styles.title}>Admin control center</Text>
           <Text style={styles.subtitle}>Manage platform users and oversee auctions</Text>
         </View>
-        <Pressable onPress={logout} style={styles.logoutButton}>
+        <Pressable onPress={handleLogout} style={styles.logoutButton}>
           <Text style={styles.logout}>Log out</Text>
         </Pressable>
       </View>

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -12,6 +12,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { listAuctions } from '../api/client';
 import LoadingOverlay from '../components/LoadingOverlay';
 import { useAuth } from '../context/AuthContext';
+import useLogoutHandler from '../hooks/useLogoutHandler';
 
 function AuctionCard({ auction, onPress, highlight }) {
   const previewImage =
@@ -82,6 +83,8 @@ export default function AuctionListScreen({ navigation }) {
   const [error, setError] = useState(null);
   const [activeTabKey, setActiveTabKey] = useState('all');
 
+  const handleLogout = useLogoutHandler(logout);
+
   const currentTab = useMemo(
     () => TABS.find((tab) => tab.key === activeTabKey) || TABS[0],
     [activeTabKey],
@@ -145,7 +148,7 @@ export default function AuctionListScreen({ navigation }) {
     <View style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>Live auctions</Text>
-        <Pressable onPress={logout}>
+        <Pressable onPress={handleLogout}>
           <Text style={styles.logout}>Log out</Text>
         </Pressable>
       </View>

--- a/frontend/src/screens/SellerHomeScreen.js
+++ b/frontend/src/screens/SellerHomeScreen.js
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useAuth } from '../context/AuthContext';
+import useLogoutHandler from '../hooks/useLogoutHandler';
 import AdminNewAuctionForm from '../components/AdminNewAuctionForm';
 import AuctionManagementList from '../components/AuctionManagementList';
 
@@ -9,6 +10,8 @@ export default function SellerHomeScreen() {
   const { logout, accessToken } = useAuth();
   const [activeTab, setActiveTab] = useState('create');
   const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleLogout = useLogoutHandler(logout);
 
   useFocusEffect(
     useCallback(() => {
@@ -31,7 +34,7 @@ export default function SellerHomeScreen() {
           <Text style={styles.title}>Seller workspace</Text>
           <Text style={styles.subtitle}>Publish new auctions and manage your listings</Text>
         </View>
-        <Pressable onPress={logout} style={styles.logoutButton}>
+        <Pressable onPress={handleLogout} style={styles.logoutButton}>
           <Text style={styles.logout}>Log out</Text>
         </Pressable>
       </View>


### PR DESCRIPTION
## Summary
- add a shared logout handler that resets navigation to the login stack
- switch the admin, seller, and buyer dashboards to use the shared handler for consistent logout behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcbb5a41a08330b6676ba30005fe56