### PR TITLE
Ensure logout resets navigation

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useMemo, useReducer } from 'react';
+import { resetToLogin } from '../navigation/navigationRef';
 
 const AuthContext = createContext(null);
 
@@ -39,6 +40,7 @@ export function AuthProvider({ children }) {
       },
       logout() {
         dispatch({ type: 'LOGOUT' });
+        resetToLogin();
       },
     }),
     [state],


### PR DESCRIPTION
## Summary
- ensure the auth context triggers a navigation reset when logging out so buyers return to the login screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcbf56da48833088cc27321a380298