### PR TITLE
Hide expired auctions from buyer all-auctions tab

### DIFF
--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -190,6 +190,9 @@ export default function AuctionListScreen({ navigation }) {
           keyExtractor={(item) => item.id}
           renderItem={({ item }) => {
             const expired = isAuctionExpired(item);
+            if (currentTab.key === 'all' && expired) {
+              return null;
+            }
             const highlight =
               currentTab.key === 'participating' && expired
                 ? item?.best_bid?.buyer_id === userId


### PR DESCRIPTION
## Summary
- prevent expired auctions from rendering when viewing all auctions by filtering during render

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcc395547483309ada5df09e6af1e5