### PR TITLE
Ensure username logins ignore email collisions

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -81,9 +81,11 @@ def login():
     if not identifier or not password:
         abort(HTTPStatus.BAD_REQUEST, description="Missing credentials")
 
-    user = User.query.filter(
-        (User.username == identifier) | (User.email == identifier)
-    ).first()
+    if "@" in identifier:
+        normalized_email = identifier.lower()
+        user = User.query.filter(func.lower(User.email) == normalized_email).first()
+    else:
+        user = User.query.filter(User.username == identifier).first()
     if user is None or not check_password_hash(user.password_hash, password):
         abort(HTTPStatus.UNAUTHORIZED, description="Invalid credentials")
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,64 @@
+"""Authentication-specific regression tests."""
+from __future__ import annotations
+
+
+PASSWORD = "ComplexPass123!"
+
+
+def test_login_is_case_insensitive_for_email(client):
+    register_response = client.post(
+        "/auth/register",
+        json={
+            "username": "casebuyer",
+            "email": "buyer@example.com",
+            "password": PASSWORD,
+        },
+    )
+    assert register_response.status_code == 201
+
+    login_response = client.post(
+        "/auth/login",
+        json={
+            "usernameOrEmail": "BUYER@EXAMPLE.COM",
+            "password": PASSWORD,
+        },
+    )
+
+    assert login_response.status_code == 200
+    body = login_response.get_json()
+    assert "access" in body
+    assert body["user"]["username"] == "casebuyer"
+
+
+def test_username_login_does_not_match_other_user_email(client):
+    first_response = client.post(
+        "/auth/register",
+        json={
+            "username": "uniqueuser",
+            "email": "unique@example.com",
+            "password": PASSWORD,
+        },
+    )
+    assert first_response.status_code == 201
+
+    second_response = client.post(
+        "/auth/register",
+        json={
+            "username": "anotheruser",
+            "email": "uniqueuser@example.com",
+            "password": PASSWORD,
+        },
+    )
+    assert second_response.status_code == 201
+
+    login_response = client.post(
+        "/auth/login",
+        json={
+            "usernameOrEmail": "uniqueuser",
+            "password": PASSWORD,
+        },
+    )
+
+    assert login_response.status_code == 200
+    body = login_response.get_json()
+    assert body["user"]["username"] == "uniqueuser"


### PR DESCRIPTION
## Summary
- prefer username lookups over email lookups during authentication so a username cannot resolve to another account's email address
- add regression coverage to confirm username logins do not authenticate other users who share the same email local-part

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd33793db083308075c7bd035d054c