### PR TITLE
Enable zoomable auction images

### DIFF
--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import {
   Alert,
   Image,
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -36,6 +37,7 @@ export default function AuctionDetailScreen({ route }) {
   const [bidAmount, setBidAmount] = useState('');
   const [isSubmitting, setSubmitting] = useState(false);
   const [activeImageIndex, setActiveImageIndex] = useState(0);
+  const [isImageModalVisible, setImageModalVisible] = useState(false);
 
   const loadAuction = async () => {
     setLoading(true);
@@ -105,7 +107,21 @@ export default function AuctionDetailScreen({ route }) {
       <Text style={styles.title}>{auction.title}</Text>
       <Text style={styles.subtitle}>{auction.description}</Text>
       {heroImage ? (
-        <Image source={{ uri: heroImage }} style={styles.heroImage} resizeMode="cover" />
+        <>
+          <Pressable onPress={() => setImageModalVisible(true)} accessibilityRole="imagebutton">
+            <Image source={{ uri: heroImage }} style={styles.heroImage} resizeMode="cover" />
+          </Pressable>
+          <Modal
+            visible={isImageModalVisible}
+            transparent
+            animationType="fade"
+            onRequestClose={() => setImageModalVisible(false)}
+          >
+            <Pressable style={styles.modalBackdrop} onPress={() => setImageModalVisible(false)}>
+              <Image source={{ uri: heroImage }} style={styles.modalImage} resizeMode="contain" />
+            </Pressable>
+          </Modal>
+        </>
       ) : null}
       {imageUrls.length > 1 ? (
         <View style={styles.thumbnailGrid}>
@@ -308,5 +324,16 @@ const styles = StyleSheet.create({
   info: {
     marginTop: 24,
     color: '#6f6f6f',
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+  modalImage: {
+    width: '100%',
+    height: '80%',
   },
 });


### PR DESCRIPTION
## Summary
- add a modal overlay that opens when the primary auction image is tapped
- allow the enlarged image to close when tapping the backdrop for a quick return
- style the modal to center the image on a darkened background for better focus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe0527dc148330878627ae023e4d98