### PR TITLE
Remove minimum auction price requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a Flask-based backend prototype for the AutoBet MVP des
 - JWT authentication with role-based access control for admins, sellers, and buyers.
 - Administrative APIs for user provisioning and status updates.
 - Seller-facing auction CRUD with automatic 24h window enforcement and notification fan-out.
-- Buyer bidding API with validation of minimum price, highest bid requirement, and two-bid limit per auction.
+- Buyer bidding API with validation of positive bid amounts, highest bid requirement, and two-bid limit per auction.
 - Notification registry endpoints for Expo push tokens plus persistence of notification events.
 - `/time` endpoint exposing canonical server time for client countdown synchronization.
 - SQLAlchemy models aligned with the proposed data schema (users, auctions, bids, notifications, audit logs, devices).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -84,7 +84,6 @@ class Auction(BaseModel):
 
     title: Mapped[str] = mapped_column(db.String(255), nullable=False)
     description: Mapped[str] = mapped_column(db.Text, nullable=False)
-    min_price: Mapped[float] = mapped_column(db.Numeric(10, 2), nullable=False)
     currency: Mapped[str] = mapped_column(db.String(3), default="EUR", nullable=False)
     image_urls: Mapped[list[str]] = mapped_column(db.JSON, default=list)
     carte_grise_image_url: Mapped[str | None] = mapped_column(db.Text)

--- a/backend/app/routes/bids.py
+++ b/backend/app/routes/bids.py
@@ -62,10 +62,6 @@ def place_bid(auction_id: uuid.UUID):
     if amount_decimal <= 0:
         abort(HTTPStatus.BAD_REQUEST, description="Bid amount must be positive")
 
-    min_price = Decimal(str(auction.min_price))
-    if amount_decimal < min_price:
-        abort(HTTPStatus.BAD_REQUEST, description="Bid below minimum price")
-
     bid = Bid(
         auction_id=auction_id,
         buyer_id=user.id,

--- a/backend/tests/test_auction_flow.py
+++ b/backend/tests/test_auction_flow.py
@@ -75,7 +75,6 @@ def test_seller_can_create_and_buyer_can_bid(client):
         json={
             "title": "Tesla Model S",
             "description": "Performance trim",
-            "min_price": 50000,
             "currency": "EUR",
             "images": ["https://example.com/car.jpg"],
             "carte_grise_image": "https://example.com/carte-grise.jpg",
@@ -133,7 +132,6 @@ def test_second_buyer_can_bid_below_best(client):
         json={
             "title": "Peugeot 208",
             "description": "GT Line",
-            "min_price": 20000,
             "currency": "EUR",
             "images": ["https://example.com/peugeot-front.jpg"],
             "carte_grise_image": "https://example.com/peugeot-carte.jpg",
@@ -195,7 +193,6 @@ def test_seller_can_edit_and_delete_after_bid(client):
         json={
             "title": "Citroen DS",
             "description": "Showroom condition",
-            "min_price": 42000,
             "currency": "EUR",
             "images": ["https://example.com/ds-front.jpg"],
             "carte_grise_image": "https://example.com/ds-carte.jpg",
@@ -260,7 +257,6 @@ def test_buyer_cannot_exceed_bid_limit(client):
         json={
             "title": "Renault 5",
             "description": "Classic",
-            "min_price": 1000,
             "carte_grise_image": "https://example.com/carte-grise-renault.jpg",
         },
     )
@@ -323,7 +319,6 @@ def test_create_auction_requires_carte_grise_image(client):
         json={
             "title": "Missing Carte Grise",
             "description": "Should fail",
-            "min_price": 5000,
         },
     )
     assert create_response.status_code == 400
@@ -355,7 +350,6 @@ def test_seller_can_update_images_with_descriptor_payload(client):
         json={
             "title": "Land Rover Defender",
             "description": "Classic 110",
-            "min_price": 35000,
             "carte_grise_image": "https://example.com/carte-grise-defender.jpg",
         },
     )

--- a/frontend/src/components/AdminNewAuctionForm.js
+++ b/frontend/src/components/AdminNewAuctionForm.js
@@ -18,7 +18,6 @@ import { useAuth } from '../context/AuthContext';
 export default function AdminNewAuctionForm({ onCreated }) {
   const { accessToken } = useAuth();
   const [title, setTitle] = useState('');
-  const [minPrice, setMinPrice] = useState('');
   const [description, setDescription] = useState('');
   const [selectedImages, setSelectedImages] = useState([]);
   const [carteGriseImage, setCarteGriseImage] = useState(null);
@@ -123,12 +122,6 @@ export default function AdminNewAuctionForm({ onCreated }) {
       return;
     }
 
-    const numericMinPrice = Number(minPrice);
-    if (!minPrice || Number.isNaN(numericMinPrice) || numericMinPrice <= 0) {
-      Alert.alert('Invalid price', 'Enter a valid minimum price greater than 0.');
-      return;
-    }
-
     if (!carteGriseImage) {
       Alert.alert('Carte grise required', 'Upload the vehicle carte grise before publishing.');
       return;
@@ -140,7 +133,6 @@ export default function AdminNewAuctionForm({ onCreated }) {
         {
           title: trimmedTitle,
           description: trimmedDescription,
-          min_price: numericMinPrice,
           currency: 'EUR',
           images: selectedImages.map((item) => item.dataUrl),
           carte_grise_image: carteGriseImage.dataUrl,
@@ -148,7 +140,6 @@ export default function AdminNewAuctionForm({ onCreated }) {
         accessToken,
       );
       setTitle('');
-      setMinPrice('');
       setDescription('');
       setSelectedImages([]);
       setCarteGriseImage(null);
@@ -194,17 +185,6 @@ export default function AdminNewAuctionForm({ onCreated }) {
             onChangeText={setDescription}
             multiline
             textAlignVertical="top"
-          />
-        </View>
-
-        <View style={styles.fieldGroup}>
-          <Text style={styles.label}>Minimum price (EUR)</Text>
-          <TextInput
-            style={styles.input}
-            placeholder="e.g. 25000"
-            keyboardType="decimal-pad"
-            value={minPrice}
-            onChangeText={setMinPrice}
           />
         </View>
 

--- a/frontend/src/components/AuctionManagementList.js
+++ b/frontend/src/components/AuctionManagementList.js
@@ -74,12 +74,6 @@ function AuctionRow({
         </Text>
       ) : null}
       <View style={styles.cardRow}>
-        <Text style={styles.cardLabel}>Minimum price</Text>
-        <Text style={styles.cardValue}>
-          {auction.min_price} {auction.currency}
-        </Text>
-      </View>
-      <View style={styles.cardRow}>
         <Text style={styles.cardLabel}>Highest bidder</Text>
         <Text style={[styles.cardValue, !bestBid && styles.cardValueMuted]}>
           {highestBidderLabel}
@@ -124,7 +118,7 @@ export default function AuctionManagementList({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [editingId, setEditingId] = useState(null);
-  const [formValues, setFormValues] = useState({ title: '', description: '', min_price: '' });
+  const [formValues, setFormValues] = useState({ title: '', description: '' });
   const [formImages, setFormImages] = useState([]);
   const [formCarteGriseImage, setFormCarteGriseImage] = useState(null);
   const [saving, setSaving] = useState(false);
@@ -172,7 +166,6 @@ export default function AuctionManagementList({
         setFormValues({
           title: detail.title || '',
           description: detail.description || '',
-          min_price: String(detail.min_price ?? ''),
         });
         const existingImages = Array.isArray(detail.image_urls)
           ? detail.image_urls
@@ -204,7 +197,7 @@ export default function AuctionManagementList({
 
   const cancelEdit = () => {
     setEditingId(null);
-    setFormValues({ title: '', description: '', min_price: '' });
+    setFormValues({ title: '', description: '' });
     setFormImages([]);
     setFormCarteGriseImage(null);
   };
@@ -303,12 +296,6 @@ export default function AuctionManagementList({
       Alert.alert('Missing description', 'Please describe the vehicle.');
       return;
     }
-    const numericPrice = Number(formValues.min_price);
-    if (!formValues.min_price || Number.isNaN(numericPrice) || numericPrice <= 0) {
-      Alert.alert('Invalid price', 'Enter a minimum price greater than 0.');
-      return;
-    }
-
     if (!formCarteGriseImage) {
       Alert.alert('Carte grise required', 'Upload the carte grise before saving changes.');
       return;
@@ -321,7 +308,6 @@ export default function AuctionManagementList({
         {
           title: formValues.title.trim(),
           description: formValues.description.trim(),
-          min_price: numericPrice,
           images: formImages.map((item) => item.dataUrl),
           carte_grise_image: formCarteGriseImage.dataUrl,
         },
@@ -449,13 +435,6 @@ export default function AuctionManagementList({
           <Text style={styles.cartePlaceholder}>No carte grise uploaded yet.</Text>
         )}
       </View>
-      <TextInput
-        style={styles.input}
-        placeholder="Minimum price"
-        keyboardType="decimal-pad"
-        value={formValues.min_price}
-        onChangeText={(value) => setFormValues((current) => ({ ...current, min_price: value }))}
-      />
       <View style={styles.editActions}>
         <Pressable
           onPress={cancelEdit}

--- a/frontend/src/components/SellerAuctionBrowseList.js
+++ b/frontend/src/components/SellerAuctionBrowseList.js
@@ -26,12 +26,6 @@ function AuctionPreviewCard({ auction, onPress }) {
       ) : null}
       <Text style={styles.cardTitle}>{auction.title}</Text>
       <View style={styles.cardRow}>
-        <Text style={styles.cardLabel}>Minimum price</Text>
-        <Text style={styles.cardValue}>
-          {auction.min_price} {auction.currency}
-        </Text>
-      </View>
-      <View style={styles.cardRow}>
         <Text style={styles.cardLabel}>Best bid</Text>
         <Text style={styles.cardValue}>
           {hasBestBid ? `${bestBid.amount} ${auction.currency}` : 'No bids yet'}

--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -147,7 +147,6 @@ export default function AuctionDetailScreen({ route }) {
           </Pressable>
         </View>
       ) : null}
-      <Text style={styles.meta}>Minimum price: {auction.min_price} {auction.currency}</Text>
       <Text style={styles.meta}>Status: {auction.status}</Text>
       {auction.end_at ? (
         <Text style={styles.meta}>Ends at {new Date(auction.end_at).toLocaleString()}</Text>

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -37,12 +37,6 @@ function AuctionCard({ auction, onPress, highlight }) {
           {auction.description}
         </Text>
       ) : null}
-      <View style={styles.cardRow}>
-        <Text style={styles.cardLabel}>Minimum:</Text>
-        <Text style={styles.cardValue}>
-          {auction.min_price} {auction.currency}
-        </Text>
-      </View>
       {auction.end_at ? (
         <Text style={styles.cardMeta}>Ends at {new Date(auction.end_at).toLocaleString()}</Text>
       ) : null}


### PR DESCRIPTION
## Summary
- remove the minimum price field from the auction model and related API validation
- adjust bid placement to only require positive amounts and update integration tests
- update mobile client screens and forms to stop displaying or requiring a minimum price

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68ff550995a483308727203604f0d655