### PR TITLE
Display highest bid in seller auction management

### DIFF
--- a/frontend/src/components/AuctionManagementList.js
+++ b/frontend/src/components/AuctionManagementList.js
@@ -41,6 +41,7 @@ function AuctionRow({
   const bestBid = auction.best_bid;
   const highestBidder = bestBid?.buyer_username || null;
   const highestBidderLabel = bestBid ? highestBidder || 'Unknown bidder' : 'No bids yet';
+  const highestBidLabel = bestBid ? `${bestBid.amount} ${auction.currency}` : 'No bids yet';
   const isSellerView = mode === 'seller';
   const hasWinningBid = Boolean(bestBid && highestBidder);
   const isExpired = auction.end_at ? new Date(auction.end_at) < new Date() : false;
@@ -77,6 +78,12 @@ function AuctionRow({
         <Text style={styles.cardLabel}>Highest bidder</Text>
         <Text style={[styles.cardValue, !bestBid && styles.cardValueMuted]}>
           {highestBidderLabel}
+        </Text>
+      </View>
+      <View style={styles.cardRow}>
+        <Text style={styles.cardLabel}>Highest bid</Text>
+        <Text style={[styles.cardValue, !bestBid && styles.cardValueMuted]}>
+          {highestBidLabel}
         </Text>
       </View>
       {auction.end_at ? (


### PR DESCRIPTION
## Summary
- show the current highest bid amount beneath the bidder information in the seller auction management cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff5905e85c8330b1ea67ddcaa8e84e