### PR TITLE
Avoid duplicate auction loads on first focus

### DIFF
--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -268,6 +268,9 @@ export default function AuctionListScreen({ navigation }) {
 
   useFocusEffect(
     useCallback(() => {
+      if (isFirstLoadRef.current) {
+        return;
+      }
       loadAuctions(currentTab, { forceReload: true });
     }, [currentTab, loadAuctions]),
   );


### PR DESCRIPTION
## Summary
- prevent the first focus event from reloading auctions when the initial load is still pending

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff6efbdd0c833083d7124d73df06ce