### PR TITLE
Fix duplicate auction list request after login

### DIFF
--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -258,12 +258,22 @@ export default function AuctionListScreen({ navigation }) {
   );
 
   useEffect(() => {
-    const cachedEntry = cacheRef.current.get(currentTab.key);
-    const shouldShowSpinner = isFirstLoadRef.current || !cachedEntry;
-    loadAuctions(currentTab, { showSpinner: shouldShowSpinner, forceReload: !cachedEntry });
-    if (isFirstLoadRef.current) {
-      isFirstLoadRef.current = false;
-    }
+    let isActive = true;
+
+    const runInitialLoad = async () => {
+      const cachedEntry = cacheRef.current.get(currentTab.key);
+      const shouldShowSpinner = isFirstLoadRef.current || !cachedEntry;
+      await loadAuctions(currentTab, { showSpinner: shouldShowSpinner, forceReload: !cachedEntry });
+      if (isActive && isFirstLoadRef.current) {
+        isFirstLoadRef.current = false;
+      }
+    };
+
+    runInitialLoad();
+
+    return () => {
+      isActive = false;
+    };
   }, [currentTab, loadAuctions]);
 
   useFocusEffect(


### PR DESCRIPTION
## Summary
- delay resetting the first-load flag until the initial auction fetch completes
- prevent the focus effect from issuing a redundant request when the screen first mounts
- guard against state updates after unmount during the initial load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff734314c0833089ee65b1e23eab5e