### PR TITLE
Make screens transparent to show shared background image

### DIFF
--- a/frontend/src/screens/AdminHomeScreen.js
+++ b/frontend/src/screens/AdminHomeScreen.js
@@ -75,7 +75,7 @@ export default function AdminHomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f4f8',
+    backgroundColor: 'transparent',
   },
   header: {
     paddingTop: 48,

--- a/frontend/src/screens/AuctionDetailScreen.js
+++ b/frontend/src/screens/AuctionDetailScreen.js
@@ -199,7 +199,7 @@ export default function AuctionDetailScreen({ route }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f4f8',
+    backgroundColor: 'transparent',
   },
   content: {
     padding: 16,

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -372,7 +372,7 @@ export default function AuctionListScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f4f8',
+    backgroundColor: 'transparent',
   },
   header: {
     paddingTop: 48,

--- a/frontend/src/screens/LoginScreen.js
+++ b/frontend/src/screens/LoginScreen.js
@@ -74,7 +74,7 @@ export default function LoginScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f4f8',
+    backgroundColor: 'transparent',
     justifyContent: 'center',
     padding: 24,
   },

--- a/frontend/src/screens/RegisterScreen.js
+++ b/frontend/src/screens/RegisterScreen.js
@@ -82,7 +82,7 @@ export default function RegisterScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f4f8',
+    backgroundColor: 'transparent',
     justifyContent: 'center',
     padding: 24,
   },

--- a/frontend/src/screens/SellerHomeScreen.js
+++ b/frontend/src/screens/SellerHomeScreen.js
@@ -69,7 +69,7 @@ export default function SellerHomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f4f8',
+    backgroundColor: 'transparent',
   },
   header: {
     paddingTop: 48,


### PR DESCRIPTION
## Summary
- make the main containers on login, register, auction list/detail, admin, and seller screens transparent so the shared background image shows through

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff7516a6ac8330abe671b6eed16c5c