### PR TITLE
Prevent stale auction list updates

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,6 +1,6 @@
 const BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000';
 
-async function request(path, { method = 'GET', body, token } = {}) {
+async function request(path, { method = 'GET', body, token, signal } = {}) {
   const headers = { 'Content-Type': 'application/json' };
   if (token) {
     headers.Authorization = `Bearer ${token}`;
@@ -10,6 +10,7 @@ async function request(path, { method = 'GET', body, token } = {}) {
     method,
     headers,
     body: body ? JSON.stringify(body) : undefined,
+    signal,
   });
 
   if (!response.ok) {
@@ -47,13 +48,16 @@ export async function login({ usernameOrEmail, password }) {
   });
 }
 
-export async function listAuctions({
-  status = 'active',
-  sort = 'fresh',
-  scope,
-  createdAfter,
-  token,
-} = {}) {
+export async function listAuctions(
+  {
+    status = 'active',
+    sort = 'fresh',
+    scope,
+    createdAfter,
+    token,
+  } = {},
+  { signal } = {},
+) {
   const params = new URLSearchParams();
   if (status) {
     params.append('status', status);
@@ -69,7 +73,7 @@ export async function listAuctions({
   }
   const query = params.toString();
   const suffix = query ? `?${query}` : '';
-  return request(`/auctions${suffix}`, { token });
+  return request(`/auctions${suffix}`, { token, signal });
 }
 
 export async function fetchAuction(auctionId) {


### PR DESCRIPTION
## Summary
- add abort controller support to auction list requests so calls can be cancelled
- track per-tab request ids in the auction list screen and ignore stale responses
- guard state updates by the active tab to prevent cross-tab data leaks

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ff774a5cec83308eed40df0a0a2d0f