### PR TITLE
Brighten workspace text for dark background

### DIFF
--- a/frontend/src/components/AdminNewAuctionForm.js
+++ b/frontend/src/components/AdminNewAuctionForm.js
@@ -169,6 +169,7 @@ export default function AdminNewAuctionForm({ onCreated }) {
           <TextInput
             style={styles.input}
             placeholder="e.g. 2019 Tesla Model 3"
+            placeholderTextColor="#94a3b8"
             value={title}
             onChangeText={setTitle}
             autoCapitalize="words"
@@ -181,6 +182,7 @@ export default function AdminNewAuctionForm({ onCreated }) {
           <TextInput
             style={[styles.input, styles.multiline]}
             placeholder="Highlight the vehicle condition, mileage, upgrades, etc."
+            placeholderTextColor="#94a3b8"
             value={description}
             onChangeText={setDescription}
             multiline
@@ -261,13 +263,14 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     marginTop: 24,
     marginBottom: 8,
+    color: '#ffffff',
   },
   helper: {
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     marginBottom: 16,
   },
   helperSmall: {
-    color: '#6f6f6f',
+    color: '#cbd5f5',
     marginTop: 6,
     fontSize: 12,
   },
@@ -277,15 +280,17 @@ const styles = StyleSheet.create({
   label: {
     fontWeight: '600',
     marginBottom: 8,
+    color: '#f8fafc',
   },
   input: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
     borderRadius: 12,
     paddingHorizontal: 14,
     paddingVertical: 12,
     borderWidth: 1,
-    borderColor: '#d0d5dd',
+    borderColor: 'rgba(148, 163, 184, 0.5)',
     fontSize: 16,
+    color: '#f8fafc',
   },
   multiline: {
     minHeight: 120,
@@ -298,7 +303,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     paddingVertical: 24,
     alignItems: 'center',
-    backgroundColor: '#eef3ff',
+    backgroundColor: 'rgba(15, 98, 254, 0.12)',
   },
   uploadButtonDisabled: {
     opacity: 0.5,
@@ -320,9 +325,9 @@ const styles = StyleSheet.create({
     marginRight: 8,
     marginBottom: 8,
     position: 'relative',
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
     borderWidth: 1,
-    borderColor: '#d0d5dd',
+    borderColor: 'rgba(148, 163, 184, 0.5)',
   },
   thumbnail: {
     width: '100%',
@@ -366,8 +371,8 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: 'hidden',
     borderWidth: 1,
-    borderColor: '#d0d5dd',
-    backgroundColor: '#fff',
+    borderColor: 'rgba(148, 163, 184, 0.5)',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
   },
   carteImage: {
     width: 200,

--- a/frontend/src/components/AuctionManagementList.js
+++ b/frontend/src/components/AuctionManagementList.js
@@ -499,7 +499,7 @@ const styles = StyleSheet.create({
   },
   helperText: {
     textAlign: 'center',
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     marginTop: 32,
   },
   errorText: {
@@ -517,12 +517,12 @@ const styles = StyleSheet.create({
     paddingBottom: 40,
   },
   card: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
     borderRadius: 14,
     padding: 16,
     marginBottom: 12,
     shadowColor: '#000',
-    shadowOpacity: 0.05,
+    shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 3,
   },
@@ -530,16 +530,16 @@ const styles = StyleSheet.create({
     transform: [{ scale: 0.99 }],
   },
   cardHighlighted: {
-    backgroundColor: '#e8f0ff',
+    backgroundColor: 'rgba(15, 98, 254, 0.2)',
     borderWidth: 1,
-    borderColor: '#bcd4ff',
+    borderColor: 'rgba(15, 98, 254, 0.6)',
   },
   cardImage: {
     width: '100%',
     height: 140,
     borderRadius: 10,
     marginBottom: 12,
-    backgroundColor: '#e5e5e5',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
   },
   cardHeader: {
     flexDirection: 'row',
@@ -552,9 +552,10 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     flex: 1,
     marginRight: 12,
+    color: '#ffffff',
   },
   cardDescription: {
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     marginBottom: 8,
   },
   cardStatus: {
@@ -569,18 +570,18 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   cardLabel: {
-    color: '#6f6f6f',
+    color: '#e5e7eb',
     fontWeight: '500',
   },
   cardValue: {
-    color: '#0f62fe',
+    color: '#9cc4ff',
     fontWeight: '600',
   },
   cardValueMuted: {
-    color: '#6f6f6f',
+    color: '#cbd5f5',
   },
   cardMeta: {
-    color: '#6f6f6f',
+    color: '#e5e7eb',
     fontSize: 12,
     marginBottom: 12,
   },
@@ -614,11 +615,11 @@ const styles = StyleSheet.create({
   },
   editCard: {
     marginTop: 16,
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
     borderRadius: 14,
     padding: 16,
     shadowColor: '#000',
-    shadowOpacity: 0.08,
+    shadowOpacity: 0.35,
     shadowRadius: 10,
     elevation: 4,
   },
@@ -626,6 +627,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
     marginBottom: 12,
+    color: '#ffffff',
   },
   input: {
     borderWidth: 1,
@@ -635,6 +637,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     marginBottom: 12,
     fontSize: 16,
+    color: '#ffffff',
   },
   multiline: {
     minHeight: 90,
@@ -656,12 +659,12 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   imageButtonLabel: {
-    color: '#0f62fe',
+    color: '#9cc4ff',
     fontWeight: '600',
   },
   imageHelper: {
     marginTop: 6,
-    color: '#6f6f6f',
+    color: '#cbd5f5',
     fontSize: 12,
   },
   imageGrid: {
@@ -677,9 +680,9 @@ const styles = StyleSheet.create({
     marginRight: 8,
     marginBottom: 8,
     position: 'relative',
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
     borderWidth: 1,
-    borderColor: '#d0d5dd',
+    borderColor: 'rgba(255, 255, 255, 0.2)',
   },
   imageThumbnail: {
     width: '100%',
@@ -707,6 +710,7 @@ const styles = StyleSheet.create({
   carteLabel: {
     fontWeight: '600',
     marginBottom: 8,
+    color: '#ffffff',
   },
   carteButton: {
     borderWidth: 1,
@@ -718,12 +722,12 @@ const styles = StyleSheet.create({
     backgroundColor: '#eef3ff',
   },
   carteButtonLabel: {
-    color: '#0f62fe',
+    color: '#9cc4ff',
     fontWeight: '600',
   },
   carteHelper: {
     marginTop: 6,
-    color: '#6f6f6f',
+    color: '#cbd5f5',
     fontSize: 12,
   },
   cartePreview: {
@@ -733,8 +737,8 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: 'hidden',
     borderWidth: 1,
-    borderColor: '#d0d5dd',
-    backgroundColor: '#fff',
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
   },
   carteImage: {
     width: 200,
@@ -753,12 +757,12 @@ const styles = StyleSheet.create({
   },
   cartePlaceholder: {
     marginTop: 10,
-    color: '#6f6f6f',
+    color: '#cbd5f5',
     fontSize: 12,
   },
   imagePlaceholder: {
     marginTop: 10,
-    color: '#6f6f6f',
+    color: '#cbd5f5',
     fontSize: 12,
   },
   editActions: {
@@ -770,10 +774,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderRadius: 10,
-    backgroundColor: '#eef2ff',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
   },
   cancelLabel: {
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     fontWeight: '600',
   },
   saveButton: {

--- a/frontend/src/components/SellerAuctionBrowseList.js
+++ b/frontend/src/components/SellerAuctionBrowseList.js
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
   },
   helperText: {
     textAlign: 'center',
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     marginTop: 24,
   },
   errorText: {
@@ -148,18 +148,18 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   infoText: {
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     marginBottom: 16,
     textAlign: 'center',
     fontSize: 14,
   },
   card: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
     borderRadius: 14,
     padding: 16,
     marginBottom: 12,
     shadowColor: '#000',
-    shadowOpacity: 0.05,
+    shadowOpacity: 0.25,
     shadowRadius: 8,
     elevation: 2,
   },
@@ -168,12 +168,13 @@ const styles = StyleSheet.create({
     height: 140,
     borderRadius: 10,
     marginBottom: 12,
-    backgroundColor: '#e5e5e5',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
   },
   cardTitle: {
     fontSize: 18,
     fontWeight: '600',
     marginBottom: 12,
+    color: '#ffffff',
   },
   cardRow: {
     flexDirection: 'row',
@@ -181,7 +182,7 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   cardLabel: {
-    color: '#6f6f6f',
+    color: '#e5e7eb',
     fontWeight: '500',
   },
   cardValue: {
@@ -190,7 +191,7 @@ const styles = StyleSheet.create({
   },
   cardStatus: {
     marginTop: 8,
-    color: '#6f6f6f',
+    color: '#e5e7eb',
     fontSize: 12,
     fontWeight: '600',
     textTransform: 'uppercase',

--- a/frontend/src/screens/AdminHomeScreen.js
+++ b/frontend/src/screens/AdminHomeScreen.js
@@ -92,24 +92,25 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '700',
+    color: '#ffffff',
   },
   subtitle: {
     marginTop: 4,
-    color: '#4a4a4a',
+    color: '#e2e8f0',
   },
   logoutButton: {
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
-    backgroundColor: '#ffe5e5',
+    backgroundColor: 'rgba(217, 45, 32, 0.12)',
   },
   logout: {
-    color: '#d92d20',
+    color: '#fca5a5',
     fontWeight: '600',
   },
   tabBar: {
     flexDirection: 'row',
-    backgroundColor: '#e0e5f2',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
     marginHorizontal: 20,
     borderRadius: 12,
     padding: 4,
@@ -121,15 +122,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   tabButtonActive: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
     shadowColor: '#000',
-    shadowOpacity: 0.08,
+    shadowOpacity: 0.2,
     shadowRadius: 6,
     elevation: 2,
   },
   tabLabel: {
     fontWeight: '500',
-    color: '#3d3d3d',
+    color: '#e2e8f0',
   },
   tabLabelActive: {
     color: '#0f62fe',

--- a/frontend/src/screens/AuctionListScreen.js
+++ b/frontend/src/screens/AuctionListScreen.js
@@ -450,10 +450,11 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '700',
+    color: '#ffffff',
   },
   subtitle: {
     marginTop: 4,
-    color: '#4a4a4a',
+    color: '#e2e8f0',
   },
   logoutButton: {
     paddingHorizontal: 12,
@@ -472,7 +473,7 @@ const styles = StyleSheet.create({
   },
   tabBar: {
     flexDirection: 'row',
-    backgroundColor: '#e0e5f2',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
     marginHorizontal: 20,
     borderRadius: 12,
     padding: 4,
@@ -484,9 +485,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   tabButtonActive: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
     shadowColor: '#000',
-    shadowOpacity: 0.08,
+    shadowOpacity: 0.2,
     shadowRadius: 6,
     elevation: 2,
   },
@@ -495,7 +496,7 @@ const styles = StyleSheet.create({
   },
   tabLabel: {
     fontWeight: '500',
-    color: '#3d3d3d',
+    color: '#e2e8f0',
   },
   tabLabelActive: {
     color: '#0f62fe',
@@ -510,12 +511,12 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
   },
   card: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
     borderRadius: 16,
     padding: 16,
     marginBottom: 12,
     shadowColor: '#000',
-    shadowOpacity: 0.05,
+    shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 3,
   },
@@ -523,29 +524,30 @@ const styles = StyleSheet.create({
     opacity: 0.95,
   },
   cardHighlightWon: {
-    backgroundColor: '#e6f4ea',
+    backgroundColor: 'rgba(52, 168, 83, 0.18)',
     borderWidth: 1,
-    borderColor: '#34a853',
+    borderColor: 'rgba(52, 168, 83, 0.6)',
   },
   cardHighlightLost: {
-    backgroundColor: '#fdecec',
+    backgroundColor: 'rgba(217, 48, 37, 0.18)',
     borderWidth: 1,
-    borderColor: '#d93025',
+    borderColor: 'rgba(217, 48, 37, 0.6)',
   },
   cardImage: {
     width: '100%',
     height: 160,
     borderRadius: 12,
     marginBottom: 12,
-    backgroundColor: '#e5e5e5',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
   },
   cardTitle: {
     fontSize: 18,
     fontWeight: '600',
     marginBottom: 6,
+    color: '#ffffff',
   },
   cardDescription: {
-    color: '#4a4a4a',
+    color: '#e2e8f0',
     marginBottom: 12,
   },
   cardBidAmount: {
@@ -559,7 +561,7 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   cardLabel: {
-    color: '#6f6f6f',
+    color: '#e5e7eb',
     fontWeight: '500',
   },
   cardValue: {
@@ -568,7 +570,7 @@ const styles = StyleSheet.create({
   },
   cardMeta: {
     marginTop: 8,
-    color: '#6f6f6f',
+    color: '#e5e7eb',
     fontSize: 12,
   },
   emptyContainer: {
@@ -577,6 +579,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   emptyText: {
-    color: '#6f6f6f',
+    color: '#e5e7eb',
   },
 });

--- a/frontend/src/screens/SellerHomeScreen.js
+++ b/frontend/src/screens/SellerHomeScreen.js
@@ -86,24 +86,25 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '700',
+    color: '#ffffff',
   },
   subtitle: {
     marginTop: 4,
-    color: '#4a4a4a',
+    color: '#e2e8f0',
   },
   logoutButton: {
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
-    backgroundColor: '#ffe5e5',
+    backgroundColor: 'rgba(217, 45, 32, 0.12)',
   },
   logout: {
-    color: '#d92d20',
+    color: '#fca5a5',
     fontWeight: '600',
   },
   tabBar: {
     flexDirection: 'row',
-    backgroundColor: '#e0e5f2',
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
     marginHorizontal: 20,
     borderRadius: 12,
     padding: 4,
@@ -115,15 +116,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   tabButtonActive: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
     shadowColor: '#000',
-    shadowOpacity: 0.08,
+    shadowOpacity: 0.2,
     shadowRadius: 6,
     elevation: 2,
   },
   tabLabel: {
     fontWeight: '500',
-    color: '#3d3d3d',
+    color: '#e2e8f0',
   },
   tabLabelActive: {
     color: '#0f62fe',


### PR DESCRIPTION
## Summary
- lighten admin and seller workspace headers, tabs, and logout accents so they contrast against the dark background
- refresh the auction creation form with brighter labels, helper text, and translucent inputs suited for the darker theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff7b25bd44833099ca9b1379a844d2