### PR TITLE
Add admin auction timeframe filtering and CSV export

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",
+        "@react-native-community/datetimepicker": "^8.1.3",
         "@react-navigation/native": "^7.1.18",
         "@react-navigation/native-stack": "^7.5.1",
         "base-64": "^1.0.0",
@@ -2320,6 +2321,29 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.5.0.tgz",
+      "integrity": "sha512-RMWll1aPppMtzdJz4we4poNzVj9WUw5URHID7D2ICjGZq3KjrwwexvBnzp75EIYE/ihHXCn/OvYKe73fws9Y/g==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
+    "@react-native-community/datetimepicker": "^8.1.3",
     "@react-navigation/native": "^7.1.18",
     "@react-navigation/native-stack": "^7.5.1",
     "base-64": "^1.0.0",


### PR DESCRIPTION
## Summary
- add created_at range filtering and CSV export endpoint for admin auction management
- include seller metadata in auction previews and add backend tests covering date filters and CSV export
- add admin UI date range picker with CSV download support and update API client plus dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690085c115c88330b02888e8cfca3bb2