### PR TITLE
Load Expo backend URL from env via config

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,13 +27,16 @@ This directory contains a lightweight Expo/React Native client for interacting w
    npx expo install react-native-web react-dom @expo/metro-runtime
    ```
 
-2. Optionally configure the backend URL exposed to the Expo client by creating an `.env` file in this folder:
+2. Optionally configure the backend URL exposed to the Expo client by creating an `.env` file in this folder (make sure to restart `npm start` after changing it):
 
    ```bash
    echo "EXPO_PUBLIC_API_URL=http://127.0.0.1:5000" > .env
    ```
 
    When omitted, the app falls back to `http://127.0.0.1:5000`.
+
+   The Expo config (`app.config.js`) loads this value via `dotenv` and exposes it through `Constants.expoConfig.extra.apiUrl`,
+   so it is available for local `npm start` sessions and cloud builds alike.
 
 3. Start the backend if it is not already running:
 

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,0 +1,37 @@
+import 'dotenv/config';
+
+export default ({ config }) => ({
+  ...config,
+  expo: {
+    name: 'AutoBizz',
+    slug: 'autobizz',
+    version: '1.0.0',
+    orientation: 'portrait',
+    icon: './assets/icon.png',
+    splash: {
+      image: './assets/splash.png',
+      resizeMode: 'contain',
+      backgroundColor: '#ffffff',
+    },
+    updates: {
+      fallbackToCacheTimeout: 0,
+    },
+    assetBundlePatterns: ['**/*'],
+    ios: {
+      supportsTablet: true,
+    },
+    android: {
+      adaptiveIcon: {
+        foregroundImage: './assets/adaptive-icon.png',
+        backgroundColor: '#ffffff',
+      },
+    },
+    web: {
+      bundler: 'metro',
+      favicon: './assets/favicon.png',
+    },
+    extra: {
+      apiUrl: process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000',
+    },
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^7.1.18",
         "@react-navigation/native-stack": "^7.5.1",
         "base-64": "^1.0.0",
+        "dotenv": "^17.2.3",
         "expo": "~54.0.20",
         "expo-constants": "~16.0.2",
         "expo-device": "~6.0.1",
@@ -1714,6 +1715,18 @@
         "getenv": "^2.0.0"
       }
     },
+    "node_modules/@expo/env/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@expo/fingerprint": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.2.tgz",
@@ -1873,6 +1886,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@expo/metro-runtime": {
@@ -4026,9 +4051,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4045,6 +4070,18 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -4424,6 +4461,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/expo-constants/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/expo-constants/node_modules/find-up": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native": "^7.1.18",
     "@react-navigation/native-stack": "^7.5.1",
     "base-64": "^1.0.0",
+    "dotenv": "^17.2.3",
     "expo": "~54.0.20",
     "expo-constants": "~16.0.2",
     "expo-device": "~6.0.1",

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,4 +1,7 @@
-const BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000';
+import Constants from 'expo-constants';
+
+const BASE_URL =
+  Constants.expoConfig?.extra?.apiUrl || process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000';
 
 async function request(path, { method = 'GET', body, token, signal } = {}) {
   const headers = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Summary
- load Expo configuration from `app.config.js` so `.env` values are read via `dotenv`
- read the API base URL through `Constants.expoConfig.extra.apiUrl` with a fallback
- document how the `.env` value is picked up and remind to restart the dev server after changes

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d4efaf508330978da826a1e5a35c)