### PR TITLE
Remove placeholder Expo assets

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,4 +1,7 @@
-import 'dotenv/config';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 export default ({ config }) => ({
   ...config,


### PR DESCRIPTION
## Summary
- remove the previously added placeholder PNG assets from the Expo frontend assets directory

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2701fbc483309e9b55669225c620)