### PR TITLE
Fix Expo env loading for API URL

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,7 +1,7 @@
 import Constants from 'expo-constants';
 
-const BASE_URL =
-  Constants.expoConfig?.extra?.apiUrl || process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000';
+const extra = Constants.expoConfig?.extra || Constants.manifest?.extra;
+const BASE_URL = extra?.apiUrl || process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000';
 
 async function request(path, { method = 'GET', body, token, signal } = {}) {
   const headers = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Summary
- add missing fs import so Expo config can detect .env files
- ensure API client reads apiUrl from Expo extra manifest or process env

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2c3c62f08330b2e4bc65250fe1bf)