### PR TITLE
Log Expo API URL during app startup

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -115,6 +115,10 @@ export default function App() {
     },
   };
 
+  useEffect(() => {
+    console.log('EXPO_PUBLIC_API_URL:', process.env.EXPO_PUBLIC_API_URL);
+  }, []);
+
   return (
     <ImageBackground source={require('./src/bg.jpeg')} style={styles.background} resizeMode="cover">
       <AuthProvider>


### PR DESCRIPTION
## Summary
- add an App-level useEffect to log the EXPO_PUBLIC_API_URL once the app mounts
- keep existing navigation and push registration intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a35b6b3a48330bdd597c8f49f06d7)