### PR TITLE
Show fallback API URL in Expo config

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
+import Constants from 'expo-constants';
 import { ImageBackground, StyleSheet } from 'react-native';
 import AuctionDetailScreen from './src/screens/AuctionDetailScreen';
 import AuctionListScreen from './src/screens/AuctionListScreen';
@@ -11,7 +12,7 @@ import AdminHomeScreen from './src/screens/AdminHomeScreen';
 import SellerHomeScreen from './src/screens/SellerHomeScreen';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
 import { navigationRef, resetToLogin } from './src/navigation/navigationRef';
-import { registerDevice } from './src/api/client';
+import { BASE_URL, registerDevice } from './src/api/client';
 import { registerForPushNotificationsAsync } from './src/utils/push';
 
 const Stack = createNativeStackNavigator();
@@ -114,6 +115,12 @@ export default function App() {
       background: 'transparent',
     },
   };
+
+  useEffect(() => {
+    console.log('EXPO_PUBLIC_API_URL (process):', process.env.EXPO_PUBLIC_API_URL);
+    console.log('EXPO config extra apiUrl:', Constants.expoConfig?.extra?.apiUrl);
+    console.log('Resolved BASE_URL:', BASE_URL);
+  }, []);
 
   return (
     <ImageBackground source={require('./src/bg.jpeg')} style={styles.background} resizeMode="cover">

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,13 +27,22 @@ This directory contains a lightweight Expo/React Native client for interacting w
    npx expo install react-native-web react-dom @expo/metro-runtime
    ```
 
-2. Optionally configure the backend URL exposed to the Expo client by creating an `.env` file in this folder (make sure to restart `npm start` after changing it). The app reads `EXPO_PUBLIC_API_URL` directly from `process.env`—no additional Expo config is needed:
+2. Optionally configure the backend URL exposed to the Expo client by creating an `.env` file in this folder (make sure to restart `npm start` after changing it). `app.config.js` loads this file via `dotenv` and injects `EXPO_PUBLIC_API_URL` into Expo config so the value is available even when `process.env` is empty inside Metro. If no `.env` is found, the Expo config still exposes `extra.apiUrl` with the default `http://127.0.0.1:5000`:
 
    ```bash
    echo "EXPO_PUBLIC_API_URL=http://127.0.0.1:5000" > .env
    ```
 
    When omitted, the app falls back to `http://127.0.0.1:5000`.
+
+   To confirm Metro can see your `.env`, run `npx expo config --json | jq '.extra.apiUrl'` from the `frontend/` folder and verify the output matches your configured URL. If you see the fallback `"http://127.0.0.1:5000"`, Metro did not pick up your `.env`.
+
+   **If `EXPO_PUBLIC_API_URL` shows up as `undefined`, check the following:**
+
+   - Restart Metro with cache cleared (`npx expo start -c`). Environment variables are only read when the bundler starts.
+   - Ensure the `.env` file sits directly in the `frontend/` folder (next to `package.json`) and the key is spelled exactly `EXPO_PUBLIC_API_URL` without quotes or spaces.
+   - Run `npm run start` from the `frontend/` directory so Expo can see the `.env` file.
+   - Confirm the value is also present in Expo config (`Constants.expoConfig.extra.apiUrl`), which is logged on app startup.
 
 3. Start the backend if it is not already running:
 
@@ -54,7 +63,8 @@ This directory contains a lightweight Expo/React Native client for interacting w
 ```
 frontend/
 ├── App.js                 # Navigation + root provider wiring
-├── app.json               # Expo configuration
+├── app.json               # Legacy static Expo configuration (most values live in app.config.js)
+├── app.config.js          # Expo configuration with dotenv support for EXPO_PUBLIC_API_URL
 ├── package.json           # Dependencies and scripts
 ├── assets/                # Placeholder icons for Expo builds
 └── src/

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,0 +1,38 @@
+import 'dotenv/config';
+
+const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? 'http://127.0.0.1:5000';
+
+export default {
+  expo: {
+    name: 'AutoBizz',
+    slug: 'autobizz',
+    version: '1.0.0',
+    orientation: 'portrait',
+    icon: './assets/icon.png',
+    splash: {
+      image: './assets/splash.png',
+      resizeMode: 'contain',
+      backgroundColor: '#ffffff',
+    },
+    updates: {
+      fallbackToCacheTimeout: 0,
+    },
+    assetBundlePatterns: ['**/*'],
+    ios: {
+      supportsTablet: true,
+    },
+    android: {
+      adaptiveIcon: {
+        foregroundImage: './assets/adaptive-icon.png',
+        backgroundColor: '#ffffff',
+      },
+    },
+    web: {
+      bundler: 'metro',
+      favicon: './assets/favicon.png',
+    },
+    extra: {
+      apiUrl,
+    },
+  },
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^7.1.18",
         "@react-navigation/native-stack": "^7.5.1",
         "base-64": "^1.0.0",
+        "dotenv": "^16.4.5",
         "expo": "~54.0.20",
         "expo-constants": "~16.0.2",
         "expo-device": "~6.0.1",
@@ -4049,6 +4050,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dotenv-expand": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
@@ -4057,18 +4070,6 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dotenv-expand/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "expo-notifications": "~0.28.14",
     "expo-sharing": "~14.0.7",
     "expo-status-bar": "~3.0.8",
+    "dotenv": "^16.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,4 +1,9 @@
-const BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://127.0.0.1:5000';
+import Constants from 'expo-constants';
+
+export const BASE_URL =
+  process.env.EXPO_PUBLIC_API_URL ||
+  Constants.expoConfig?.extra?.apiUrl ||
+  'http://127.0.0.1:5000';
 
 async function request(path, { method = 'GET', body, token, signal } = {}) {
   const headers = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Summary
- expose a default backend URL in Expo config so extra.apiUrl is always present
- clarify README instructions for verifying whether Metro picked up the .env file

## Testing
- EXPO_PUBLIC_API_URL=https://example.com npx expo config --json | jq '.extra.apiUrl'


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a35b6b3a48330bdd597c8f49f06d7)