### PR TITLE
Document production TLS hosting for web UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,32 @@ This frontend is now a browser-only web client. It ships as static HTML/CSS/JS i
 
    <http://localhost:8080/frontend/web-ui/>
 
+## Production hosting (TLS + reverse proxy)
+
+Gunicorn should run the Flask backend only. In production, serve the static UI with a web server/reverse proxy (Nginx, Caddy, Apache) and terminate TLS there. The proxy can serve `frontend/web-ui/` as static files and forward API requests (for example `/api`) to `http://127.0.0.1:8000`.
+
+If you have TLS certificates in `backend/certs`, reference those certificate paths from your proxy config (or move them to the location your proxy expects). Example Nginx configuration (paths are illustrative):
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name your-domain.example;
+
+  ssl_certificate     /home/debian/AutoBizz/backend/certs/server.crt;
+  ssl_certificate_key /home/debian/AutoBizz/backend/certs/server.key;
+
+  root /home/debian/AutoBizz/frontend/web-ui;
+  index index.html;
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:8000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}
+```
+
 ## Pointing at a different backend
 
 If your backend is hosted elsewhere, expose the URL before loading the page:


### PR DESCRIPTION
### Motivation

- Clarify recommended production deployment so the static web UI is served securely and certificates are managed by a reverse proxy rather than trying to make Gunicorn handle TLS and static assets. 
- Provide a concrete example showing how existing cert files in `backend/certs` can be reused by the proxy and how API requests should be forwarded to the backend.

### Description

- Added a "Serving the UI in production (TLS + reverse proxy)" section to `README.md` that recommends terminating TLS at a reverse proxy and keeping Gunicorn as the backend process only. 
- Added a matching "Production hosting (TLS + reverse proxy)" section to `frontend/README.md` with the same guidance and an example Nginx configuration referencing `backend/certs/server.crt` and `backend/certs/server.key`. 
- The docs instruct the proxy to serve `frontend/web-ui/` as static files and to proxy API requests (for example `/api`) to `http://127.0.0.1:8000` with `X-Forwarded-Proto: https` so the backend recognizes secure requests.

### Testing

- Automated tests were not run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e375a910c8330a6daa99904689d3a)