### PR TITLE
Add Nginx setup steps for production UI hosting

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,68 @@ This frontend is now a browser-only web client. It ships as static HTML/CSS/JS i
 
    <http://localhost:8080/frontend/web-ui/>
 
+## Production hosting (TLS + reverse proxy)
+
+Gunicorn should run the Flask backend only. In production, serve the static UI with a web server/reverse proxy (Nginx, Caddy, Apache) and terminate TLS there. The proxy can serve `frontend/web-ui/` as static files and forward API requests (for example `/api`) to `http://127.0.0.1:8000`.
+
+If you have TLS certificates in `backend/certs`, reference those certificate paths from your proxy config (or move them to the location your proxy expects). Example Nginx configuration (paths are illustrative):
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name your-domain.example;
+
+  ssl_certificate     /home/debian/AutoBizz/backend/certs/server.crt;
+  ssl_certificate_key /home/debian/AutoBizz/backend/certs/server.key;
+
+  root /home/debian/AutoBizz/frontend/web-ui;
+  index index.html;
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:8000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}
+```
+
+### Nginx setup steps (Debian/Ubuntu)
+
+1. Install Nginx (if needed):
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y nginx
+   ```
+
+2. Create a site config file, for example:
+
+   ```bash
+   sudo nano /etc/nginx/sites-available/autobizz
+   ```
+
+3. Paste the `server { ... }` block above, and replace:
+   - `server_name` with your domain.
+   - `ssl_certificate`/`ssl_certificate_key` with your actual cert paths.
+   - `root` with the absolute path to `frontend/web-ui`.
+
+4. Enable the site and disable the default (optional but common):
+
+   ```bash
+   sudo ln -s /etc/nginx/sites-available/autobizz /etc/nginx/sites-enabled/autobizz
+   sudo rm -f /etc/nginx/sites-enabled/default
+   ```
+
+5. Check the config and reload Nginx:
+
+   ```bash
+   sudo nginx -t
+   sudo systemctl reload nginx
+   ```
+
+6. Ensure Gunicorn is running on `http://127.0.0.1:8000` so `/api/` requests can be proxied correctly.
+
 ## Pointing at a different backend
 
 If your backend is hosted elsewhere, expose the URL before loading the page:


### PR DESCRIPTION
### Motivation

- Clarify how to serve the static web UI securely in production by terminating TLS at a reverse proxy and keeping Gunicorn as the backend process. 
- Provide concrete, actionable steps for setting up Nginx (including which site file to edit) so users can reuse certificates in `backend/certs` and proxy API requests. 
- Reduce confusion around serving static assets and API traffic from a single Gunicorn process.

### Description

- Added Nginx/TLS guidance and an example `server { ... }` block to `README.md` and mirrored the same instructions in `frontend/README.md` to keep the UI docs close to the web client. 
- Included a step-by-step `Nginx setup steps (Debian/Ubuntu)` section that shows installing Nginx, creating `/etc/nginx/sites-available/autobizz`, pasting the example `server { ... }` block, and adjusting `server_name`, `ssl_certificate`/`ssl_certificate_key`, and `root`. 
- Documented enabling the site via the sites-available/sites-enabled layout and the recommended verification and reload commands `nginx -t` and `sudo systemctl reload nginx`. 
- Reminded to ensure the backend/Gunicorn is reachable at `http://127.0.0.1:8000` so that `location /api/` proxying works as expected.

### Testing

- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e375a910c8330a6daa99904689d3a)